### PR TITLE
Add linting configuration and side config to enforce tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,26 +1,33 @@
 {
+    "parser": "babel-eslint",
     "env": {
-        "node": true,
-        "browser": true,
+        "commonjs": true,
         "es6": true,
+        "node": true,
         "jest": true
     },
-    "extends": ["eslint:recommended", "plugin:react/recommended"],
-    "parser": "babel-eslint",
-    "globals": {
-        "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
-    },
+    "extends": [
+        "eslint:recommended",
+        "standard",
+        "plugin:jest/recommended",
+        "plugin:react/recommended",
+        "plugin:flowtype/recommended"
+    ],
     "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 2018,
-        "sourceType": "module"
+        "ecmaVersion": 2018
     },
     "plugins": [
-        "react"
+        "react-hooks",
+        "flowtype"
     ],
     "rules": {
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "error"
+    },
+    "settings": {
+        "react": {
+            "version": "detect",
+            "flowVersion": "detect"
+        }
     }
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,1 @@
-export { wrapRootElement } from './src/apollo/wrap-root-element';
+export { wrapRootElement } from './src/apollo/wrap-root-element'

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,58 +1,58 @@
-var proxy = require("http-proxy-middleware");
+var proxy = require('http-proxy-middleware')
 
-const deployContext = process.env.DEPLOY_CONTEXT;
-const isProduction = deployContext === "production";
+const deployContext = process.env.DEPLOY_CONTEXT
+const isProduction = deployContext === 'production'
 let siteUrl =
   process.env.DEPLOY_URL ||
   process.env.DEPLOY_PRIME_URL ||
-  "http://localhost:8000";
+  'http://localhost:8000'
 
 if (isProduction) {
-  siteUrl = process.env.URL;
+  siteUrl = process.env.URL
 }
 
 module.exports = {
   siteMetadata: {
-    title: `Student Debt Strike | Join today!`,
-    description: `Join the movement to end Student Debt. #CancelStudentDebt #CollegeForAll`,
-    author: "Debt Collective",
-    twitterUsername: `@0debtzone`,
-    facebookPage: "https://www.facebook.com/DebtCollective",
+    title: 'Student Debt Strike | Join today!',
+    description: 'Join the movement to end Student Debt. #CancelStudentDebt #CollegeForAll',
+    author: 'Debt Collective',
+    twitterUsername: '@0debtzone',
+    facebookPage: 'https://www.facebook.com/DebtCollective',
     image: `${siteUrl}/img/seo.png`,
     url: siteUrl
   },
   plugins: [
-    "gatsby-plugin-react-helmet",
-    "gatsby-plugin-sass",
+    'gatsby-plugin-react-helmet',
+    'gatsby-plugin-sass',
     {
       // keep as first gatsby-source-filesystem plugin for gatsby image support
-      resolve: "gatsby-source-filesystem",
+      resolve: 'gatsby-source-filesystem',
       options: {
         path: `${__dirname}/static/img`,
-        name: "uploads"
+        name: 'uploads'
       }
     },
     {
-      resolve: "gatsby-source-filesystem",
+      resolve: 'gatsby-source-filesystem',
       options: {
         path: `${__dirname}/src/pages`,
-        name: "pages"
+        name: 'pages'
       }
     },
-    "gatsby-plugin-sharp",
-    "gatsby-transformer-sharp",
+    'gatsby-plugin-sharp',
+    'gatsby-transformer-sharp',
     {
-      resolve: "gatsby-transformer-remark",
+      resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [
           {
-            resolve: "gatsby-remark-relative-images",
+            resolve: 'gatsby-remark-relative-images',
             options: {
-              name: "uploads"
+              name: 'uploads'
             }
           },
           {
-            resolve: "gatsby-remark-images",
+            resolve: 'gatsby-remark-images',
             options: {
               // It's important to specify the maxWidth (in pixels) of
               // the content container as this plugin uses this as the
@@ -61,40 +61,40 @@ module.exports = {
             }
           },
           {
-            resolve: "gatsby-remark-copy-linked-files",
+            resolve: 'gatsby-remark-copy-linked-files',
             options: {
-              destinationDir: "static"
+              destinationDir: 'static'
             }
           }
         ]
       }
     },
     {
-      resolve: "gatsby-plugin-netlify-cms",
+      resolve: 'gatsby-plugin-netlify-cms',
       options: {
         modulePath: `${__dirname}/src/cms/cms.js`
       }
     },
     {
-      resolve: "gatsby-plugin-purgecss", // purges all unused/unreferenced css rules
+      resolve: 'gatsby-plugin-purgecss', // purges all unused/unreferenced css rules
       options: {
         develop: true, // Activates purging in npm run develop
-        purgeOnly: ["/all.sass"] // applies purging only on the bulma css file
+        purgeOnly: ['/all.sass'] // applies purging only on the bulma css file
       }
     }, // must be after other CSS plugins
-    "gatsby-plugin-netlify" // make sure to keep it last in the array
+    'gatsby-plugin-netlify' // make sure to keep it last in the array
   ],
   // for avoiding CORS while developing Netlify Functions locally
   // read more: https://www.gatsbyjs.org/docs/api-proxy/#advanced-proxying
   developMiddleware: app => {
     app.use(
-      "/.netlify/functions/",
+      '/.netlify/functions/',
       proxy({
-        target: "http://localhost:9000",
+        target: 'http://localhost:9000',
         pathRewrite: {
-          "/.netlify/functions/": ""
+          '/.netlify/functions/': ''
         }
       })
-    );
+    )
   }
-};
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,10 @@
-const _ = require("lodash");
-const path = require("path");
-const { createFilePath } = require("gatsby-source-filesystem");
-const { fmImagesToRelative } = require("gatsby-remark-relative-images");
+const _ = require('lodash')
+const path = require('path')
+const { createFilePath } = require('gatsby-source-filesystem')
+const { fmImagesToRelative } = require('gatsby-remark-relative-images')
 
 exports.createPages = ({ actions, graphql }) => {
-  const { createPage } = actions;
+  const { createPage } = actions
 
   return graphql(`
     {
@@ -24,14 +24,14 @@ exports.createPages = ({ actions, graphql }) => {
     }
   `).then(result => {
     if (result.errors) {
-      result.errors.forEach(e => console.error(e.toString()));
-      return Promise.reject(result.errors);
+      result.errors.forEach(e => console.error(e.toString()))
+      return Promise.reject(result.errors)
     }
 
-    const posts = result.data.allMarkdownRemark.edges;
+    const posts = result.data.allMarkdownRemark.edges
 
     posts.forEach(edge => {
-      const id = edge.node.id;
+      const id = edge.node.id
       createPage({
         path: edge.node.fields.slug,
         tags: edge.node.frontmatter.tags,
@@ -42,45 +42,45 @@ exports.createPages = ({ actions, graphql }) => {
         context: {
           id
         }
-      });
-    });
+      })
+    })
 
     // Tag pages:
-    let tags = [];
+    let tags = []
     // Iterate through each post, putting all found tags into `tags`
     posts.forEach(edge => {
-      if (_.get(edge, `node.frontmatter.tags`)) {
-        tags = tags.concat(edge.node.frontmatter.tags);
+      if (_.get(edge, 'node.frontmatter.tags')) {
+        tags = tags.concat(edge.node.frontmatter.tags)
       }
-    });
+    })
     // Eliminate duplicate tags
-    tags = _.uniq(tags);
+    tags = _.uniq(tags)
 
     // Make tag pages
     tags.forEach(tag => {
-      const tagPath = `/tags/${_.kebabCase(tag)}/`;
+      const tagPath = `/tags/${_.kebabCase(tag)}/`
 
       createPage({
         path: tagPath,
-        component: path.resolve(`src/templates/tags.js`),
+        component: path.resolve('src/templates/tags.js'),
         context: {
           tag
         }
-      });
-    });
-  });
-};
+      })
+    })
+  })
+}
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
-  const { createNodeField } = actions;
-  fmImagesToRelative(node); // convert image paths for gatsby images
+  const { createNodeField } = actions
+  fmImagesToRelative(node) // convert image paths for gatsby images
 
-  if (node.internal.type === `MarkdownRemark`) {
-    const value = createFilePath({ node, getNode });
+  if (node.internal.type === 'MarkdownRemark') {
+    const value = createFilePath({ node, getNode })
     createNodeField({
-      name: `slug`,
+      name: 'slug',
       node,
       value
-    });
+    })
   }
-};
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,1 +1,1 @@
-export { wrapRootElement } from './src/apollo/wrap-root-element';
+export { wrapRootElement } from './src/apollo/wrap-root-element'

--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,5 +1,5 @@
 const babelOptions = {
-  presets: [`babel-preset-gatsby`]
-};
+  presets: ['babel-preset-gatsby']
+}
 
-module.exports = require(`babel-jest`).createTransformer(babelOptions);
+module.exports = require('babel-jest').createTransformer(babelOptions)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,17 @@
 module.exports = {
   transform: {
-    "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`
+    '^.+\\.jsx?$': '<rootDir>/jest-preprocess.js'
   },
   moduleNameMapper: {
-    ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
-    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`
+    '.+\\.(css|styl|less|sass|scss)$': 'identity-obj-proxy',
+    '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/file-mock.js'
   },
-  testPathIgnorePatterns: [`node_modules`, `.cache`],
-  transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
+  testPathIgnorePatterns: ['node_modules', '.cache'],
+  transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
   globals: {
-    __PATH_PREFIX__: ``
+    __PATH_PREFIX__: ''
   },
-  testURL: `http://localhost`,
-  setupFilesAfterEnv: [`<rootDir>/jest.setup.js`],
-  setupFiles: [`<rootDir>/loadershim.js`]
-};
+  testURL: 'http://localhost',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFiles: ['<rootDir>/loadershim.js']
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,1 @@
-require(`@testing-library/jest-dom/extend-expect`);
+require('@testing-library/jest-dom/extend-expect')

--- a/loadershim.js
+++ b/loadershim.js
@@ -1,3 +1,3 @@
 global.___loader = {
   enqueue: jest.fn()
-};
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.1.3",
   "author": "Austin Green",
   "dependencies": {
-    "amplitude-js": "^5.6.0",
     "@apollo/react-hooks": "^3.1.3",
+    "amplitude-js": "^5.6.0",
     "apollo-boost": "^0.4.4",
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
@@ -54,8 +54,10 @@
     "build": "run-p build:**",
     "develop": "npm run clean && gatsby develop",
     "serve": "gatsby serve",
-    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"{gatsby-*.js,src/**/*.js}\"",
-    "test": "jest"
+    "lint": "eslint '**/*.js' --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --coverage"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
@@ -64,15 +66,36 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-preset-gatsby": "^0.2.20",
-    "eslint": "^6.3.0",
-    "eslint-plugin-react": "^7.14.3",
+    "eslint": "^6.6.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-flowtype": "^4.4.1",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^23.0.4",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-react-hooks": "^2.3.0",
+    "eslint-plugin-standard": "^4.0.1",
     "faker": "^4.1.0",
     "http-proxy-middleware": "^0.20.0",
+    "husky": "^3.1.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
+    "lint-staged": "^9.4.3",
     "netlify-lambda": "^1.4.3",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.18.2",
     "react-test-renderer": "^16.10.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "yarn test:ci",
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
   }
 }

--- a/src/__mocks__/file-mock.js
+++ b/src/__mocks__/file-mock.js
@@ -1,1 +1,1 @@
-module.exports = `test-file-stub`;
+module.exports = 'test-file-stub'

--- a/src/__mocks__/gatsby.js
+++ b/src/__mocks__/gatsby.js
@@ -1,15 +1,15 @@
-const React = require(`react`);
-const gatsby = jest.requireActual(`gatsby`);
+const React = require('react')
+const gatsby = jest.requireActual('gatsby')
 
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
   Link: jest.fn().mockImplementation(({ to, ...rest }) =>
-    React.createElement(`a`, {
+    React.createElement('a', {
       ...rest,
       href: to
     })
   ),
   StaticQuery: jest.fn(),
   useStaticQuery: jest.fn()
-};
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import gql from 'graphql-tag'
 
 /**
  * Retrive the current user data
@@ -11,4 +11,4 @@ export const GET_USER = gql`
       avatar_url
     }
   }
-`;
+`

--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -1,15 +1,15 @@
-import ApolloClient from "apollo-client";
-import fetch from "isomorphic-fetch";
-import { createHttpLink } from "apollo-link-http";
-import { InMemoryCache } from "apollo-cache-inmemory";
+import ApolloClient from 'apollo-client'
+import fetch from 'isomorphic-fetch'
+import { createHttpLink } from 'apollo-link-http'
+import { InMemoryCache } from 'apollo-cache-inmemory'
 
 const link = createHttpLink({
   uri: `${process.env.GATSBY_CAMPAIGN_API_URL}`,
-  credentials: "include"
-});
+  credentials: 'include'
+})
 
 export const client = new ApolloClient({
   cache: new InMemoryCache(),
   link,
   fetch
-});
+})

--- a/src/apollo/wrap-root-element.js
+++ b/src/apollo/wrap-root-element.js
@@ -1,12 +1,12 @@
-import React from "react";
-import { ApolloProvider } from "@apollo/react-hooks";
-import PropTypes from "prop-types";
-import { client } from "./client.js";
+import React from 'react'
+import { ApolloProvider } from '@apollo/react-hooks'
+import PropTypes from 'prop-types'
+import { client } from './client.js'
 
 export const wrapRootElement = ({ element }) => (
   <ApolloProvider client={client}>{element}</ApolloProvider>
-);
+)
 
 wrapRootElement.propTypes = {
   element: PropTypes.any
-};
+}

--- a/src/cms/cms.js
+++ b/src/cms/cms.js
@@ -1,6 +1,6 @@
-import CMS from "netlify-cms-app";
-import uploadcare from "netlify-cms-media-library-uploadcare";
-import cloudinary from "netlify-cms-media-library-cloudinary";
+import CMS from 'netlify-cms-app'
+import uploadcare from 'netlify-cms-media-library-uploadcare'
+import cloudinary from 'netlify-cms-media-library-cloudinary'
 
-CMS.registerMediaLibrary(uploadcare);
-CMS.registerMediaLibrary(cloudinary);
+CMS.registerMediaLibrary(uploadcare)
+CMS.registerMediaLibrary(cloudinary)

--- a/src/components/CampaignAction.js
+++ b/src/components/CampaignAction.js
@@ -1,13 +1,13 @@
-import React from "react";
-import delay from "lodash/delay";
-import PropTypes from "prop-types";
+import React from 'react'
+import delay from 'lodash/delay'
+import PropTypes from 'prop-types'
 
 const ACTION_TYPES = {
-  LINK: "LINK"
-};
+  LINK: 'LINK'
+}
 
 const CampaignAction = ({ config, type, onComplete }) => {
-  const { text, delay: delayTime, ...attributes } = config;
+  const { text, delay: delayTime, ...attributes } = config
 
   return (
     <div className="cta-container content">
@@ -21,14 +21,14 @@ const CampaignAction = ({ config, type, onComplete }) => {
         </a>
       ) : null}
     </div>
-  );
-};
+  )
+}
 
 CampaignAction.propTypes = {
   text: PropTypes.string,
   config: PropTypes.any,
   type: PropTypes.string,
   onComplete: PropTypes.func
-};
+}
 
-export default CampaignAction;
+export default CampaignAction

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React from 'react'
 
 const Footer = () => {
-  const currentYear = new Date().getFullYear();
+  const currentYear = new Date().getFullYear()
 
   return (
     <div className="footer">
@@ -152,7 +152,7 @@ const Footer = () => {
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default Footer;
+export default Footer

--- a/src/components/Header/__tests__/index.spec.js
+++ b/src/components/Header/__tests__/index.spec.js
@@ -1,19 +1,19 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import faker from "faker";
+import React from 'react'
+import { render } from '@testing-library/react'
+import faker from 'faker'
 
-import Header from "..";
+import Header from '..'
 
 const fakeUser = {
   id: faker.random.number(),
   username: faker.internet.email(),
   avatar_url: faker.internet.url()
-};
+}
 
-describe("when logged user", () => {
-  it("renders user profile", () => {
-    const wrapper = render(<Header user={fakeUser} />);
+describe('when logged user', () => {
+  it('renders user profile', () => {
+    const wrapper = render(<Header user={fakeUser} />)
 
-    expect(wrapper.queryByTestId("profile")).toBeInTheDocument();
-  });
-});
+    expect(wrapper.queryByTestId('profile')).toBeInTheDocument()
+  })
+})

--- a/src/components/Header/__tests__/index.spec.js
+++ b/src/components/Header/__tests__/index.spec.js
@@ -5,7 +5,7 @@ import faker from 'faker'
 import Header from '..'
 
 const fakeUser = {
-  id: faker.random.number(),
+  id: faker.random.uuid(),
   username: faker.internet.email(),
   avatar_url: faker.internet.url()
 }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,10 +1,10 @@
-import React, { useState, useLayoutEffect, useRef } from "react";
-import classNames from "classnames";
-import PropTypes from "prop-types";
+import React, { useState, useLayoutEffect, useRef } from 'react'
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
 
-import { trackOutboundLink } from "../../lib/metrics";
-import { Collapse } from "react-bootstrap";
-import { Link } from "gatsby";
+import { trackOutboundLink } from '../../lib/metrics'
+import { Collapse } from 'react-bootstrap'
+import { Link } from 'gatsby'
 
 const Profile = ({ user, ...rest }) => {
   return user.id ? (
@@ -25,8 +25,8 @@ const Profile = ({ user, ...rest }) => {
         </span>
       </a>
     </div>
-  ) : null;
-};
+  ) : null
+}
 
 Profile.propTypes = {
   user: PropTypes.shape({
@@ -34,34 +34,34 @@ Profile.propTypes = {
     username: PropTypes.string,
     id: PropTypes.string
   })
-};
+}
 
-const redirectParam = `return_url=${process.env.GATSBY_HOST_URL}/actions`;
-const loginSSOUrl = `${process.env.GATSBY_COMMUNITY_URL}/session/sso_cookies?${redirectParam}`;
-const signupSSOUrl = `${process.env.GATSBY_COMMUNITY_URL}/session/sso_cookies/signup?${redirectParam}`;
+const redirectParam = `return_url=${process.env.GATSBY_HOST_URL}/actions`
+const loginSSOUrl = `${process.env.GATSBY_COMMUNITY_URL}/session/sso_cookies?${redirectParam}`
+const signupSSOUrl = `${process.env.GATSBY_COMMUNITY_URL}/session/sso_cookies/signup?${redirectParam}`
 
 const Header = ({ user }) => {
-  const [scrollY, setScrollY] = useState(false);
-  const [open, setOpen] = useState(false);
-  const headerEl = useRef(null);
-  const isLoggedIn = user.id;
+  const [scrollY, setScrollY] = useState(false)
+  const [open, setOpen] = useState(false)
+  const headerEl = useRef(null)
+  const isLoggedIn = user.id
 
   const isScrolled =
-    headerEl.current && scrollY > headerEl.current.scrollHeight / 2;
+    headerEl.current && scrollY > headerEl.current.scrollHeight / 2
 
-  const headerClasses = classNames("header", "fixed-top", {
-    "slider-nav-open": open,
+  const headerClasses = classNames('header', 'fixed-top', {
+    'slider-nav-open': open,
     active: isScrolled
-  });
-  const menuTriggerClasses = classNames("menu-trigger", { active: open });
+  })
+  const menuTriggerClasses = classNames('menu-trigger', { active: open })
 
   useLayoutEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
+    const handleScroll = () => setScrollY(window.scrollY)
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener('scroll', handleScroll)
 
-    return () => window.removeEventListener("scroll", handleScroll);
-  });
+    return () => window.removeEventListener('scroll', handleScroll)
+  })
 
   return (
     <>
@@ -185,8 +185,8 @@ const Header = ({ user }) => {
         </div>
       </Collapse>
     </>
-  );
-};
+  )
+}
 
 Header.propTypes = {
   user: PropTypes.shape({
@@ -194,10 +194,10 @@ Header.propTypes = {
     username: PropTypes.string,
     id: PropTypes.string
   })
-};
+}
 
 Header.defaultProps = {
   user: {}
-};
+}
 
-export default Header;
+export default Header

--- a/src/components/IconWrap/index.js
+++ b/src/components/IconWrap/index.js
@@ -1,14 +1,14 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconWrap = ({ src, ...rest }) => (
   <div className="icon-wrap">
     <img src={src} {...rest} />
   </div>
-);
+)
 
 IconWrap.propTypes = {
   src: PropTypes.string
-};
+}
 
-export default IconWrap;
+export default IconWrap

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,18 +1,18 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Helmet } from "react-helmet";
-import Footer from "../components/Footer";
-import "../styles/index.scss";
-import useSiteMetadata from "./SiteMetadata";
-import { withPrefix } from "gatsby";
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Helmet } from 'react-helmet'
+import Footer from '../components/Footer'
+import '../styles/index.scss'
+import useSiteMetadata from './SiteMetadata'
+import { withPrefix } from 'gatsby'
 
-if (typeof window !== `undefined`) {
-  require("jquery");
-  require("bootstrap/js/dist/alert");
+if (typeof window !== 'undefined') {
+  require('jquery')
+  require('bootstrap/js/dist/alert')
 }
 
 const TemplateWrapper = ({ children }) => {
-  const { title, description } = useSiteMetadata();
+  const { title, description } = useSiteMetadata()
   return (
     <>
       <Helmet>
@@ -23,24 +23,24 @@ const TemplateWrapper = ({ children }) => {
         <link
           rel="apple-touch-icon"
           sizes="180x180"
-          href={`${withPrefix("/")}img/apple-touch-icon.png`}
+          href={`${withPrefix('/')}img/apple-touch-icon.png`}
         />
         <link
           rel="icon"
           type="image/png"
-          href={`${withPrefix("/")}img/favicon-32x32.png`}
+          href={`${withPrefix('/')}img/favicon-32x32.png`}
           sizes="32x32"
         />
         <link
           rel="icon"
           type="image/png"
-          href={`${withPrefix("/")}img/favicon-16x16.png`}
+          href={`${withPrefix('/')}img/favicon-16x16.png`}
           sizes="16x16"
         />
 
         <link
           rel="mask-icon"
-          href={`${withPrefix("/")}img/safari-pinned-tab.svg`}
+          href={`${withPrefix('/')}img/safari-pinned-tab.svg`}
           color="#ff4400"
         />
         <meta name="theme-color" content="#fff" />
@@ -48,11 +48,11 @@ const TemplateWrapper = ({ children }) => {
       {children}
       <Footer />
     </>
-  );
-};
+  )
+}
 
 TemplateWrapper.propTypes = {
   children: PropTypes.node
-};
+}
 
-export default TemplateWrapper;
+export default TemplateWrapper

--- a/src/components/PreviewCompatibleImage.js
+++ b/src/components/PreviewCompatibleImage.js
@@ -1,26 +1,25 @@
-import React from "react";
-import PropTypes from "prop-types";
-import Img from "gatsby-image";
+import React from 'react'
+import PropTypes from 'prop-types'
+import Img from 'gatsby-image'
 
 const PreviewCompatibleImage = ({ imageInfo }) => {
-  const imageStyle = { borderRadius: "5px" };
-  const { alt = "", childImageSharp, image } = imageInfo;
+  const imageStyle = { borderRadius: '5px' }
+  const { alt = '', childImageSharp, image } = imageInfo
 
   if (!!image && !!image.childImageSharp) {
     return (
       <Img style={imageStyle} fluid={image.childImageSharp.fluid} alt={alt} />
-    );
+    )
   }
 
-  if (!!childImageSharp) {
-    return <Img style={imageStyle} fluid={childImageSharp.fluid} alt={alt} />;
+  if (childImageSharp) {
+    return <Img style={imageStyle} fluid={childImageSharp.fluid} alt={alt} />
   }
 
-  if (!!image && typeof image === "string")
-    return <img style={imageStyle} src={image} alt={alt} />;
+  if (!!image && typeof image === 'string') { return <img style={imageStyle} src={image} alt={alt} /> }
 
-  return null;
-};
+  return null
+}
 
 PreviewCompatibleImage.propTypes = {
   imageInfo: PropTypes.shape({
@@ -29,6 +28,6 @@ PreviewCompatibleImage.propTypes = {
     image: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
     style: PropTypes.object
   }).isRequired
-};
+}
 
-export default PreviewCompatibleImage;
+export default PreviewCompatibleImage

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -5,12 +5,12 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React from "react";
-import PropTypes from "prop-types";
-import Helmet from "react-helmet";
-import { useStaticQuery, graphql } from "gatsby";
+import React from 'react'
+import PropTypes from 'prop-types'
+import Helmet from 'react-helmet'
+import { useStaticQuery, graphql } from 'gatsby'
 
-function SEO({ description, lang, meta }) {
+function SEO ({ description, lang, meta }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -27,10 +27,10 @@ function SEO({ description, lang, meta }) {
         }
       }
     `
-  );
+  )
 
-  const metaDescription = description || site.siteMetadata.description;
-  const title = site.siteMetadata.title;
+  const metaDescription = description || site.siteMetadata.description
+  const title = site.siteMetadata.title
 
   return (
     <Helmet
@@ -40,64 +40,64 @@ function SEO({ description, lang, meta }) {
       title={title}
       meta={[
         {
-          name: `description`,
+          name: 'description',
           content: metaDescription
         },
         {
-          property: `og:title`,
+          property: 'og:title',
           content: title
         },
         {
-          property: `og:description`,
+          property: 'og:description',
           content: metaDescription
         },
         {
-          property: `og:type`,
-          content: `website`
+          property: 'og:type',
+          content: 'website'
         },
         {
-          property: `og:image`,
+          property: 'og:image',
           content: site.siteMetadata.image
         },
         {
-          property: `og:url`,
+          property: 'og:url',
           content: site.siteMetadata.url
         },
         {
-          name: `twitter:card`,
-          content: `summary_large_image`
+          name: 'twitter:card',
+          content: 'summary_large_image'
         },
         {
-          name: `twitter:creator`,
+          name: 'twitter:creator',
           content: site.siteMetadata.twitterUsername
         },
         {
-          name: `twitter:title`,
+          name: 'twitter:title',
           content: title
         },
         {
-          name: `twitter:description`,
+          name: 'twitter:description',
           content: metaDescription
         },
         {
-          name: `twitter:image`,
+          name: 'twitter:image',
           content: site.siteMetadata.image
         }
       ].concat(meta)}
     />
-  );
+  )
 }
 
 SEO.defaultProps = {
-  lang: `en`,
+  lang: 'en',
   meta: [],
-  description: ``
-};
+  description: ''
+}
 
 SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object)
-};
+}
 
-export default SEO;
+export default SEO

--- a/src/components/SiteMetadata.js
+++ b/src/components/SiteMetadata.js
@@ -1,4 +1,4 @@
-import { graphql, useStaticQuery } from "gatsby";
+import { graphql, useStaticQuery } from 'gatsby'
 
 const useSiteMetadata = () => {
   const { site } = useStaticQuery(
@@ -12,8 +12,8 @@ const useSiteMetadata = () => {
         }
       }
     `
-  );
-  return site.siteMetadata;
-};
+  )
+  return site.siteMetadata
+}
 
-export default useSiteMetadata;
+export default useSiteMetadata

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,40 +1,40 @@
-import { noop } from "lodash";
+import { noop } from 'lodash'
 
-let amplitude;
+let amplitude
 
-if (typeof window !== `undefined`) {
-  amplitude = require("amplitude-js");
+if (typeof window !== 'undefined') {
+  amplitude = require('amplitude-js')
 } else {
-  amplitude = { getInstance: () => null };
+  amplitude = { getInstance: () => null }
 }
 
-const amplitudeInstance = amplitude.getInstance();
+const amplitudeInstance = amplitude.getInstance()
 
 export const trackEvent = (eventName, opts = {}, callback = noop) => {
-  if (typeof amplitude !== "object") {
-    return callback();
+  if (typeof amplitude !== 'object') {
+    return callback()
   }
 
-  amplitudeInstance.logEvent(eventName, opts, callback);
-};
+  amplitudeInstance.logEvent(eventName, opts, callback)
+}
 
 export const trackOutboundLink = event => {
-  if (typeof amplitude !== "object") {
-    return;
+  if (typeof amplitude !== 'object') {
+    return
   }
 
-  event.preventDefault();
+  event.preventDefault()
 
-  const eventName = "outbound link click";
-  const href = event.target.href;
-  const target = event.target.target;
+  const eventName = 'outbound link click'
+  const href = event.target.href
+  const target = event.target.target
   const opts = {
     href
-  };
+  }
   const callback = () => {
-    window.open(href, target);
-  };
+    window.open(href, target)
+  }
 
   // track event
-  amplitudeInstance.logEvent(eventName, opts, callback);
-};
+  amplitudeInstance.logEvent(eventName, opts, callback)
+}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,5 +1,5 @@
-import React from "react";
-import Layout from "../components/Layout";
+import React from 'react'
+import Layout from '../components/Layout'
 
 const NotFoundPage = () => (
   <Layout>
@@ -8,6 +8,6 @@ const NotFoundPage = () => (
       <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     </div>
   </Layout>
-);
+)
 
-export default NotFoundPage;
+export default NotFoundPage

--- a/src/sections/CTA/index.js
+++ b/src/sections/CTA/index.js
@@ -1,7 +1,7 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react'
+import PropTypes from 'prop-types'
 
-import IconWrap from "../../components/IconWrap";
+import IconWrap from '../../components/IconWrap'
 
 const CTA = ({ social, title, action }) => (
   <section className="cta">
@@ -31,7 +31,7 @@ const CTA = ({ social, title, action }) => (
       </div>
     </div>
   </section>
-);
+)
 
 CTA.propTypes = {
   title: PropTypes.string,
@@ -45,6 +45,6 @@ CTA.propTypes = {
       })
     )
   })
-};
+}
 
-export default CTA;
+export default CTA

--- a/src/sections/CampaignActions/__tests__/index.spec.js
+++ b/src/sections/CampaignActions/__tests__/index.spec.js
@@ -14,7 +14,7 @@ import CampaignActions from '../'
 const baseProps = {
   user: {
     id: userId,
-    name: faker.name.findName(),
+    username: faker.name.findName(),
     email: faker.internet.email()
   },
   campaignId
@@ -28,8 +28,9 @@ describe('<CampaignActions />', () => {
       </MockedProvider>
     )
 
+    // TODO: this expectation shouldn't need 'queryAllByText' but 'queryByText' instead
     expect(
-      wrapper.queryByText(new RegExp(baseProps.user.name, 'i'))
+      wrapper.queryAllByText(new RegExp(baseProps.username, 'i'))[0]
     ).toBeInTheDocument()
   })
 

--- a/src/sections/CampaignActions/__tests__/index.spec.js
+++ b/src/sections/CampaignActions/__tests__/index.spec.js
@@ -1,15 +1,15 @@
-import React from "react";
-import faker from "faker";
-import { MockedProvider } from "@apollo/react-testing";
+import React from 'react'
+import faker from 'faker'
+import { MockedProvider } from '@apollo/react-testing'
 import {
   render,
   waitForElement,
   within,
   fireEvent,
   waitForDomChange
-} from "@testing-library/react";
-import { userId, campaignId, fakeActions, mocks } from "../stubs";
-import CampaignActions from "../";
+} from '@testing-library/react'
+import { userId, campaignId, fakeActions, mocks } from '../stubs'
+import CampaignActions from '../'
 
 const baseProps = {
   user: {
@@ -18,41 +18,41 @@ const baseProps = {
     email: faker.internet.email()
   },
   campaignId
-};
+}
 
-describe("<CampaignActions />", () => {
-  it("reflects the current user logged in", () => {
+describe('<CampaignActions />', () => {
+  it('reflects the current user logged in', () => {
     const wrapper = render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <CampaignActions {...baseProps} />
       </MockedProvider>
-    );
+    )
 
     expect(
-      wrapper.queryByText(new RegExp(baseProps.user.name, "i"))
-    ).toBeInTheDocument();
-  });
+      wrapper.queryByText(new RegExp(baseProps.user.name, 'i'))
+    ).toBeInTheDocument()
+  })
 
   describe('when campaign action is type "LINK"', () => {
-    it("renders with cta link an config attributes", async () => {
+    it('renders with cta link an config attributes', async () => {
       const wrapper = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <CampaignActions {...baseProps} />
         </MockedProvider>
-      );
+      )
 
-      await waitForElement(() => wrapper.getByTestId("action-item-0"));
-      const firstActionItem = within(wrapper.getByTestId("action-item-0"));
-      const expectedFirstMockedItem = fakeActions[0];
+      await waitForElement(() => wrapper.getByTestId('action-item-0'))
+      const firstActionItem = within(wrapper.getByTestId('action-item-0'))
+      const expectedFirstMockedItem = fakeActions[0]
 
       expect(
         firstActionItem.getByText(expectedFirstMockedItem.title)
-      ).toBeInTheDocument();
+      ).toBeInTheDocument()
       expect(
         firstActionItem.getByText(expectedFirstMockedItem.description)
-      ).toBeInTheDocument();
-      expect(firstActionItem.getByTestId("action-cta")).toBeInTheDocument();
-      expect(firstActionItem.getByTestId("action-cta")).toMatchInlineSnapshot(`
+      ).toBeInTheDocument()
+      expect(firstActionItem.getByTestId('action-cta')).toBeInTheDocument()
+      expect(firstActionItem.getByTestId('action-cta')).toMatchInlineSnapshot(`
         <a
           data-testid="action-cta"
           href="foo.com"
@@ -60,36 +60,36 @@ describe("<CampaignActions />", () => {
         >
           click here to go to foo.com
         </a>
-      `);
-    });
+      `)
+    })
 
-    it("updates the completed state of the action after click and given delay", async () => {
-      const actionItemId = "action-item-0";
+    it('updates the completed state of the action after click and given delay', async () => {
+      const actionItemId = 'action-item-0'
       const wrapper = render(
         <MockedProvider mocks={mocks} addTypename={false}>
           <CampaignActions {...baseProps} />
         </MockedProvider>
-      );
+      )
 
-      await waitForElement(() => wrapper.getByTestId(actionItemId));
-      const firstActionItem = within(wrapper.getByTestId(actionItemId));
+      await waitForElement(() => wrapper.getByTestId(actionItemId))
+      const firstActionItem = within(wrapper.getByTestId(actionItemId))
 
       // We relay on the className to understand the current visible state of the item
       const firstActionStartsNoCompleted = document
         .getElementById(actionItemId)
-        .classList.contains("no-completed");
+        .classList.contains('no-completed')
 
-      fireEvent.click(firstActionItem.getByTestId("action-cta"));
+      fireEvent.click(firstActionItem.getByTestId('action-cta'))
 
-      await waitForDomChange();
+      await waitForDomChange()
 
       const firstActionChangeToCompleted = document
         .getElementById(actionItemId)
-        .classList.contains("completed");
+        .classList.contains('completed')
 
       // Assert that state of the component changes to completed after given delay
-      expect(firstActionStartsNoCompleted).toBeTruthy();
-      expect(firstActionChangeToCompleted).toBeTruthy();
-    });
-  });
-});
+      expect(firstActionStartsNoCompleted).toBeTruthy()
+      expect(firstActionChangeToCompleted).toBeTruthy()
+    })
+  })
+})

--- a/src/sections/CampaignActions/api.js
+++ b/src/sections/CampaignActions/api.js
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import gql from 'graphql-tag'
 
 export const UPDATE_USER_ACTION = gql`
   mutation userActionUpdate($userActionId: ID!, $completed: Boolean!) {
@@ -7,7 +7,7 @@ export const UPDATE_USER_ACTION = gql`
       completed
     }
   }
-`;
+`
 
 export const GET_USER_ACTIONS = gql`
   query getUserActions($userId: ID!, $campaignId: ID!) {
@@ -23,4 +23,4 @@ export const GET_USER_ACTIONS = gql`
       }
     }
   }
-`;
+`

--- a/src/sections/CampaignActions/index.js
+++ b/src/sections/CampaignActions/index.js
@@ -7,6 +7,8 @@ import CampaignAction from '../../components/CampaignAction'
 import { GET_USER_ACTIONS, UPDATE_USER_ACTION } from './api'
 
 const CampaignActions = ({ user, campaignId }) => {
+  // FIXME: flag approach needs to be removed throught #46
+  const [temporalFlagForMutationUpdate, setTemporalFlagForMutationUpdate] = useState(true)
   const [completedActions, setCompletedActions] = useState({})
   const [completeAction, { data: mutationResponse }] = useMutation(
     UPDATE_USER_ACTION
@@ -20,14 +22,15 @@ const CampaignActions = ({ user, campaignId }) => {
   })
 
   useEffect(() => {
-    if (mutationResponse) {
+    if (mutationResponse && temporalFlagForMutationUpdate) {
+      setTemporalFlagForMutationUpdate(false)
       setCompletedActions({
         ...completedActions,
         [mutationResponse.userActionUpdate.id]:
           mutationResponse.userActionUpdate.completed
       })
     }
-  }, [completedActions, mutationResponse])
+  }, [completedActions, temporalFlagForMutationUpdate, mutationResponse])
 
   return (
     <section id="campaign-actions" className="campaign-actions">

--- a/src/sections/CampaignActions/index.js
+++ b/src/sections/CampaignActions/index.js
@@ -1,23 +1,23 @@
-import React, { useState, useEffect } from "react";
-import has from "lodash/has";
-import PropTypes from "prop-types";
-import { useQuery, useMutation } from "@apollo/react-hooks";
-import Markdown from "markdown-to-jsx";
-import CampaignAction from "../../components/CampaignAction";
-import { GET_USER_ACTIONS, UPDATE_USER_ACTION } from "./api";
+import React, { useState, useEffect } from 'react'
+import has from 'lodash/has'
+import PropTypes from 'prop-types'
+import { useQuery, useMutation } from '@apollo/react-hooks'
+import Markdown from 'markdown-to-jsx'
+import CampaignAction from '../../components/CampaignAction'
+import { GET_USER_ACTIONS, UPDATE_USER_ACTION } from './api'
 
 const CampaignActions = ({ user, campaignId }) => {
-  const [completedActions, setCompletedActions] = useState({});
+  const [completedActions, setCompletedActions] = useState({})
   const [completeAction, { data: mutationResponse }] = useMutation(
     UPDATE_USER_ACTION
-  );
+  )
   const {
     loading: queryLoading,
     error: queryError,
     data: queryResponse
   } = useQuery(GET_USER_ACTIONS, {
     variables: { campaignId, userId: user.id }
-  });
+  })
 
   useEffect(() => {
     if (mutationResponse) {
@@ -25,9 +25,9 @@ const CampaignActions = ({ user, campaignId }) => {
         ...completedActions,
         [mutationResponse.userActionUpdate.id]:
           mutationResponse.userActionUpdate.completed
-      });
+      })
     }
-  }, [mutationResponse]);
+  }, [completedActions, mutationResponse])
 
   return (
     <section id="campaign-actions" className="campaign-actions">
@@ -49,23 +49,23 @@ const CampaignActions = ({ user, campaignId }) => {
             <div data-testid="action-items" className="collapsable-list">
               {(() => {
                 if (queryLoading) {
-                  return <p>Loading...</p>;
+                  return <p>Loading...</p>
                 }
 
                 if (queryError) {
-                  return <p>Error: ${queryError.message}</p>;
+                  return <p>Error: ${queryError.message}</p>
                 }
 
                 return queryResponse.userActions.map((userAction, index) => {
-                  const { action, completed } = userAction;
-                  const { title, description, config, type } = action;
+                  const { action, completed } = userAction
+                  const { title, description, config, type } = action
                   // Check if state of the action has changed within completedActions state
                   const isActionCompleted = has(completedActions, userAction.id)
                     ? completedActions[userAction.id]
-                    : completed;
+                    : completed
                   const completedClass = isActionCompleted
-                    ? "completed"
-                    : "no-completed";
+                    ? 'completed'
+                    : 'no-completed'
 
                   return (
                     <details
@@ -86,20 +86,20 @@ const CampaignActions = ({ user, campaignId }) => {
                               userActionId: userAction.id,
                               completed: true
                             }
-                          });
+                          })
                         }}
                       />
                     </details>
-                  );
-                });
+                  )
+                })
               })()}
             </div>
           </div>
         </div>
       </div>
     </section>
-  );
-};
+  )
+}
 
 CampaignActions.propTypes = {
   campaignId: PropTypes.string,
@@ -107,6 +107,6 @@ CampaignActions.propTypes = {
     id: PropTypes.string,
     username: PropTypes.string
   })
-};
+}
 
-export default CampaignActions;
+export default CampaignActions

--- a/src/sections/CampaignActions/stubs.js
+++ b/src/sections/CampaignActions/stubs.js
@@ -1,50 +1,50 @@
-import { GET_USER_ACTIONS, UPDATE_USER_ACTION } from "./api";
+import { GET_USER_ACTIONS, UPDATE_USER_ACTION } from './api'
 
-export const userId = "1";
-export const campaignId = "1";
+export const userId = '1'
+export const campaignId = '1'
 export const fakeActions = [
   {
-    id: "4",
+    id: '4',
     campaignId,
-    title: "rerum nihil",
+    title: 'rerum nihil',
     description:
-      "enim impedit commodi tempora occaecati debitis et in quia laborum",
-    type: "LINK",
+      'enim impedit commodi tempora occaecati debitis et in quia laborum',
+    type: 'LINK',
     config: {
-      text: "click here to go to foo.com",
-      href: "foo.com",
-      target: "_blank",
+      text: 'click here to go to foo.com',
+      href: 'foo.com',
+      target: '_blank',
       delay: 200
     }
   },
   {
-    id: "3",
+    id: '3',
     campaignId,
-    title: "rerum nihil",
+    title: 'rerum nihil',
     description:
-      "enim impedit commodi tempora occaecati debitis et in quia laborum",
-    type: "LINK",
+      'enim impedit commodi tempora occaecati debitis et in quia laborum',
+    type: 'LINK',
     config: {
-      text: "click here to go to bar.com",
-      href: "bar.com",
-      target: "_blank",
+      text: 'click here to go to bar.com',
+      href: 'bar.com',
+      target: '_blank',
       delay: 200
     }
   }
-];
+]
 
 export const mocks = [
   {
     request: {
       query: UPDATE_USER_ACTION,
-      variables: { userActionId: "1", completed: true }
+      variables: { userActionId: '1', completed: true }
     },
     result: {
       data: {
         userActionUpdate: {
-          id: "1",
+          id: '1',
           campaignId,
-          actionId: "4",
+          actionId: '4',
           completed: true
         }
       }
@@ -53,14 +53,14 @@ export const mocks = [
   {
     request: {
       query: UPDATE_USER_ACTION,
-      variables: { userActionId: "2", completed: true }
+      variables: { userActionId: '2', completed: true }
     },
     result: {
       data: {
         userActionUpdate: {
-          id: "2",
+          id: '2',
           campaignId,
-          actionId: "3",
+          actionId: '3',
           completed: true
         }
       }
@@ -78,16 +78,16 @@ export const mocks = [
       data: {
         userActions: [
           {
-            id: "1",
+            id: '1',
             campaignId,
-            actionId: "4",
+            actionId: '4',
             completed: false,
             action: fakeActions[0]
           },
           {
-            id: "2",
+            id: '2',
             campaignId,
-            actionId: "3",
+            actionId: '3',
             completed: false,
             action: fakeActions[1]
           }
@@ -95,4 +95,4 @@ export const mocks = [
       }
     }
   }
-];
+]

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,8 +1,8 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react'
+import PropTypes from 'prop-types'
 
-if (typeof window !== `undefined`) {
-  require("details-polyfill");
+if (typeof window !== 'undefined') {
+  require('details-polyfill')
 }
 
 const FAQ = ({ entries }) => (
@@ -32,7 +32,7 @@ const FAQ = ({ entries }) => (
       </div>
     </div>
   </section>
-);
+)
 
 FAQ.propTypes = {
   entries: PropTypes.arrayOf(
@@ -41,6 +41,6 @@ FAQ.propTypes = {
       answer: PropTypes.string
     })
   )
-};
+}
 
-export default FAQ;
+export default FAQ

--- a/src/sections/Hero/index.js
+++ b/src/sections/Hero/index.js
@@ -1,19 +1,19 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react'
+import PropTypes from 'prop-types'
 
-import IconWrap from "../../components/IconWrap";
-import { Link } from "react-scroll";
+import IconWrap from '../../components/IconWrap'
+import { Link } from 'react-scroll'
 
 const getBg = index => {
   switch (index) {
     case 1:
-      return "yellow";
+      return 'yellow'
     case 2:
-      return "green";
+      return 'green'
     default:
-      return "purple";
+      return 'purple'
   }
-};
+}
 
 const Hero = ({ title, actions, social }) => (
   <section className="hero">
@@ -25,7 +25,7 @@ const Hero = ({ title, actions, social }) => (
               {title.map(({ line }, index) => (
                 <span
                   key={`line-${index}`}
-                  className={`d-block ${index % 2 === 0 && "text-primary"}`}
+                  className={`d-block ${index % 2 === 0 && 'text-primary'}`}
                 >
                   {line}
                 </span>
@@ -37,12 +37,12 @@ const Hero = ({ title, actions, social }) => (
       <div className="row">
         <div className="col">
           <div className="action-circle-wrap">
-            {actions.map(({ join_section_id, title, image }, index) => (
+            {actions.map(({ join_section_id: joinSectionId, title, image }, index) => (
               <Link
                 duration={500}
-                key={join_section_id}
+                key={joinSectionId}
                 smooth={true}
-                to={join_section_id}
+                to={joinSectionId}
               >
                 <div className={`action-circle bg-${getBg(index)}`}>
                   <div className="action-circle__img">
@@ -82,7 +82,7 @@ const Hero = ({ title, actions, social }) => (
       </div>
     </div>
   </section>
-);
+)
 
 Hero.propTypes = {
   social: PropTypes.shape({
@@ -105,6 +105,6 @@ Hero.propTypes = {
       image: PropTypes.any
     })
   )
-};
+}
 
-export default Hero;
+export default Hero

--- a/src/sections/Informative/index.js
+++ b/src/sections/Informative/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import PropTypes from "prop-types";
-import Markdown from "markdown-to-jsx";
+import React from 'react'
+import PropTypes from 'prop-types'
+import Markdown from 'markdown-to-jsx'
 
 const Informative = ({ title, children, remark }) => (
   <section className="informative">
@@ -20,12 +20,12 @@ const Informative = ({ title, children, remark }) => (
       </div>
     </div>
   </section>
-);
+)
 
 Informative.propTypes = {
   title: PropTypes.string,
   children: PropTypes.any,
   remark: PropTypes.string
-};
+}
 
-export default Informative;
+export default Informative

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -1,9 +1,9 @@
-import React from "react";
-import PropTypes from "prop-types";
-import Markdown from "markdown-to-jsx";
+import React from 'react'
+import PropTypes from 'prop-types'
+import Markdown from 'markdown-to-jsx'
 
 const formatNumber = number =>
-  number.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
+  number.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
 
 const Join = ({
   background,
@@ -20,7 +20,7 @@ const Join = ({
     className="join"
     data-color={colour}
     id={id}
-    style={{ background: `url(${background})`, backgroundSize: "cover" }}
+    style={{ background: `url(${background})`, backgroundSize: 'cover' }}
   >
     <div className="container-fluid distribute-rows">
       <div className="row">
@@ -56,7 +56,7 @@ const Join = ({
                     <div className="our-voices__img">
                       <img
                         src={picture.publicURL}
-                        alt={`user profile picture`}
+                        alt={'user profile picture'}
                       />
                     </div>
                     <p className="our-voices__content">
@@ -71,7 +71,7 @@ const Join = ({
       </div>
     </div>
   </section>
-);
+)
 
 Join.propTypes = {
   feed: PropTypes.arrayOf(
@@ -90,6 +90,6 @@ Join.propTypes = {
   image: PropTypes.any,
   remark: PropTypes.string,
   title: PropTypes.string
-};
+}
 
-export default Join;
+export default Join

--- a/src/sections/Notification/index.js
+++ b/src/sections/Notification/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import Markdown from "markdown-to-jsx";
-import PropTypes from "prop-types";
+import React from 'react'
+import Markdown from 'markdown-to-jsx'
+import PropTypes from 'prop-types'
 
 const Notification = ({ title, children, date }) => (
   <div className="notification alert" role="alert">
@@ -22,12 +22,12 @@ const Notification = ({ title, children, date }) => (
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-);
+)
 
 Notification.propTypes = {
   title: PropTypes.string,
   children: PropTypes.any,
   date: PropTypes.string
-};
+}
 
-export default Notification;
+export default Notification

--- a/src/templates/actions-page.js
+++ b/src/templates/actions-page.js
@@ -1,42 +1,42 @@
-import React from "react";
-import { useQuery } from "@apollo/react-hooks";
+import React from 'react'
+import { useQuery } from '@apollo/react-hooks'
 
-import Layout from "../components/Layout";
-import Header from "../components/Header";
-import CampaignActions from "../sections/CampaignActions";
-import { GET_USER } from "../api";
+import Layout from '../components/Layout'
+import Header from '../components/Header'
+import CampaignActions from '../sections/CampaignActions'
+import { GET_USER } from '../api'
 
 // TODO: this campaignId needs to be pull from the server (mean while take from userActions table vs currentUser id)
-const campaignId = "2";
+const campaignId = '2'
 
 export const ActionsPageTemplate = () => {
   const {
     loading: userQueryLoading,
     error: userQueryError,
     data: userQueryResponse = {}
-  } = useQuery(GET_USER);
+  } = useQuery(GET_USER)
 
   return (
     <>
       <Header user={userQueryResponse.currentUser} />
       {userQueryLoading
-        ? "Loading"
+        ? 'Loading'
         : (userQueryError && userQueryError.message) || (
-            <CampaignActions
-              user={userQueryResponse.currentUser}
-              campaignId={campaignId}
-            />
-          )}
+          <CampaignActions
+            user={userQueryResponse.currentUser}
+            campaignId={campaignId}
+          />
+        )}
     </>
-  );
-};
+  )
+}
 
 const ActionsPage = () => {
   return (
     <Layout>
       <ActionsPageTemplate />
     </Layout>
-  );
-};
+  )
+}
 
-export default ActionsPage;
+export default ActionsPage

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -1,18 +1,18 @@
-import React from "react";
-import { useQuery } from "@apollo/react-hooks";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
+import React from 'react'
+import { useQuery } from '@apollo/react-hooks'
+import PropTypes from 'prop-types'
+import { graphql } from 'gatsby'
 
-import Layout from "../components/Layout";
-import Header from "../components/Header";
-import SEO from "../components/SEO";
-import Hero from "../sections/Hero";
-import Informative from "../sections/Informative";
-import Join from "../sections/Join";
-import Notification from "../sections/Notification";
-import FAQ from "../sections/FAQ";
-import CTA from "../sections/CTA";
-import { GET_USER } from "../api";
+import Layout from '../components/Layout'
+import Header from '../components/Header'
+import SEO from '../components/SEO'
+import Hero from '../sections/Hero'
+import Informative from '../sections/Informative'
+import Join from '../sections/Join'
+import Notification from '../sections/Notification'
+import FAQ from '../sections/FAQ'
+import CTA from '../sections/CTA'
+import { GET_USER } from '../api'
 
 export const IndexPageTemplate = ({
   hero,
@@ -21,9 +21,9 @@ export const IndexPageTemplate = ({
   cta,
   faq,
   demand,
-  join_campaign
+  join_campaign: joinCampaign
 }) => {
-  const { data: userQueryResponse = {} } = useQuery(GET_USER);
+  const { data: userQueryResponse = {} } = useQuery(GET_USER)
 
   return (
     <>
@@ -32,7 +32,7 @@ export const IndexPageTemplate = ({
       <Informative title={demand.title} remark={demand.remark}>
         {demand.content}
       </Informative>
-      {join_campaign.map(
+      {joinCampaign.map(
         ({
           id,
           background,
@@ -65,8 +65,8 @@ export const IndexPageTemplate = ({
       <FAQ entries={faq} />
       <CTA social={social} title={cta.title} action={cta.action} />
     </>
-  );
-};
+  )
+}
 
 IndexPageTemplate.propTypes = {
   join_campaign: PropTypes.arrayOf(PropTypes.any),
@@ -122,18 +122,18 @@ IndexPageTemplate.propTypes = {
       })
     )
   })
-};
+}
 
 const IndexPage = ({ data }) => {
-  const { frontmatter } = data.markdownRemark;
+  const { frontmatter } = data.markdownRemark
 
   return (
     <Layout>
       <SEO />
       <IndexPageTemplate {...frontmatter} />
     </Layout>
-  );
-};
+  )
+}
 
 IndexPage.propTypes = {
   data: PropTypes.shape({
@@ -141,9 +141,9 @@ IndexPage.propTypes = {
       frontmatter: PropTypes.object
     })
   })
-};
+}
 
-export default IndexPage;
+export default IndexPage
 
 export const pageQuery = graphql`
   query IndexPageTemplate {
@@ -223,4 +223,4 @@ export const pageQuery = graphql`
       }
     }
   }
-`;
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,6 +1541,13 @@
   resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.3.15.tgz#17cb37a272dfb9cbacf83614a5a7170e68f17d75"
   integrity sha512-rVNba1A2oMzKBg16fCrrHmCf4JjOzFhT9TWR8J+Y8iOcY4zffxtP3ke7mEsakvghHZT+9//uDOPSSeuBDW41GQ==
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
@@ -1721,6 +1728,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.9.tgz#4343e3b009f8cf5e1ed685e36097b74b4101e880"
   integrity sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw==
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -1842,6 +1854,15 @@
     "@typescript-eslint/typescript-estree" "2.7.0"
     eslint-scope "^5.0.0"
 
+"@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz#208b4164d175587e9b03ce6fea97d55f19c30ca9"
+  integrity sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.8.0"
+    eslint-scope "^5.0.0"
+
 "@typescript-eslint/parser@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.7.0.tgz#b5e6a4944e2b68dba1e7fbfd5242e09ff552fd12"
@@ -1859,6 +1880,19 @@
   dependencies:
     debug "^4.1.1"
     glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz#fcc3fe6532840085d29b75432c8a59895876aeca"
+  integrity sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
     is-glob "^4.0.1"
     lodash.unescape "4.0.1"
     semver "^6.3.0"
@@ -2227,6 +2261,11 @@ any-base@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
   integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 any-promise@^1.3.0:
   version "1.3.0"
@@ -3695,7 +3734,7 @@ cli-boxes@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
 
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
@@ -3723,6 +3762,14 @@ cli-table3@^0.5.1:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-truncate@^1.1.0:
   version "1.1.0"
@@ -4148,7 +4195,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.0:
+cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -4599,6 +4646,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 deasync@^0.1.14:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.15.tgz#788c4bbe6d32521233b28d23936de1bbadd2e112"
@@ -4712,6 +4764,11 @@ decompress@^4.0.0, decompress@^4.2.0:
     pify "^2.3.0"
     strip-dirs "^2.0.0"
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
 deep-equal@^1.0.1, deep-equal@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -4805,7 +4862,7 @@ del@^4.1.1:
     pify "^4.0.1"
     rimraf "^2.6.3"
 
-del@^5.1.0:
+del@^5.0.0, del@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
   integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
@@ -5204,6 +5261,11 @@ electron-to-chromium@^1.3.295, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz#e8265301d053d5f74e36cb876486830261fbe946"
   integrity sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
 elliptic@^6.0.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
@@ -5461,6 +5523,11 @@ eslint-config-react-app@^5.0.2:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
+eslint-config-standard@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz#b23da2b76fe5a2eba668374f246454e7058f15d4"
+  integrity sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -5488,10 +5555,25 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-es@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz#0f5f5da5f18aa21989feebe8a73eadefb3432976"
+  integrity sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==
+  dependencies:
+    eslint-utils "^1.4.2"
+    regexpp "^3.0.0"
+
 eslint-plugin-flowtype@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz#e241ebd39c0ce519345a3f074ec1ebde4cf80f2c"
   integrity sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==
+  dependencies:
+    lodash "^4.17.15"
+
+eslint-plugin-flowtype@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.4.1.tgz#b388f42bdc1237f68a8010d2ede52cd67a057e40"
+  integrity sha512-TNkrdJbvmBEIf02tjMKrYmLILV7OVwcvDUAnrnoGQZJhBMsu61X7E7/A1yvLTsFeDaqhbBx7rgsHzh4Yx7IqvA==
   dependencies:
     lodash "^4.17.15"
 
@@ -5520,6 +5602,13 @@ eslint-plugin-import@^2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
+eslint-plugin-jest@^23.0.4:
+  version "23.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.0.4.tgz#1ab81ffe3b16c5168efa72cbd4db14d335092aa0"
+  integrity sha512-OaP8hhT8chJNodUPvLJ6vl8gnalcsU/Ww1t9oR3HnGdEWjm/DdCCUXLOral+IPGAeWu/EwgVQCK/QtxALpH1Yw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
+
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
@@ -5535,12 +5624,34 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-node@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6"
+  integrity sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==
+  dependencies:
+    eslint-plugin-es "^2.0.0"
+    eslint-utils "^1.4.2"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
+eslint-plugin-promise@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
+  integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
+
 eslint-plugin-react-hooks@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
-eslint-plugin-react@^7.14.3, eslint-plugin-react@^7.16.0:
+eslint-plugin-react-hooks@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
+  integrity sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==
+
+eslint-plugin-react@^7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"
   integrity sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==
@@ -5554,6 +5665,11 @@ eslint-plugin-react@^7.14.3, eslint-plugin-react@^7.16.0:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.12.0"
+
+eslint-plugin-standard@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
+  integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -5583,7 +5699,7 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.3.0, eslint@^6.6.0:
+eslint@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.6.0.tgz#4a01a2fb48d32aacef5530ee9c5a78f11a8afd04"
   integrity sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==
@@ -5770,6 +5886,21 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execa@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-2.1.0.tgz#e5d3ecd837d2a60ec50f3da78fd39767747bbe99"
+  integrity sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
 
 execa@^3.3.0:
   version "3.3.0"
@@ -6113,7 +6244,7 @@ figgy-pudding@^3.5.1:
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
@@ -6288,6 +6419,14 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 find-versions@^3.0.0:
   version "3.1.0"
@@ -6978,6 +7117,11 @@ get-document@1:
   resolved "https://registry.yarnpkg.com/get-document/-/get-document-1.0.0.tgz#4821bce66f1c24cb0331602be6cb6b12c4f01c4b"
   integrity sha1-SCG85m8cJMsDMWAr5strEsTwHEs=
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz#6f7764f88ea11e0b514bd9bd860a132259992ca4"
+  integrity sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==
+
 get-port@^3.0.0, get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
@@ -6994,6 +7138,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -7934,6 +8083,23 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+husky@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
+  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
+  dependencies:
+    chalk "^2.4.2"
+    ci-info "^2.0.0"
+    cosmiconfig "^5.2.1"
+    execa "^1.0.0"
+    get-stdin "^7.0.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    read-pkg "^5.2.0"
+    run-node "^1.0.0"
+    slash "^3.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -8111,6 +8277,11 @@ indent-string@^2.1.0:
   integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -8614,7 +8785,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -8628,6 +8799,13 @@ is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
 
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
@@ -8693,6 +8871,11 @@ is-regex@^1.0.4:
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-relative-url@^2.0.0:
   version "2.0.0"
@@ -9626,6 +9809,70 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+lint-staged@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.4.3.tgz#f55ad5f94f6e105294bfd6499b23142961f7b982"
+  integrity sha512-PejnI+rwOAmKAIO+5UuAZU9gxdej/ovSEOAY34yMfC3OS4Ac82vCBPzAWLReR9zCPOMqeVwQRaZ3bUBpAsaL2Q==
+  dependencies:
+    chalk "^2.4.2"
+    commander "^2.20.0"
+    cosmiconfig "^5.2.1"
+    debug "^4.1.1"
+    dedent "^0.7.0"
+    del "^5.0.0"
+    execa "^2.0.3"
+    listr "^0.14.3"
+    log-symbols "^3.0.0"
+    micromatch "^4.0.2"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    string-argv "^0.3.0"
+    stringify-object "^3.3.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
+
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -9725,6 +9972,13 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
 
 lockfile@^1.0.4:
   version "1.0.4"
@@ -9845,12 +10099,35 @@ lodash@^4.0.0, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.11, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
 log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 log-update@^3.0.0:
   version "3.3.0"
@@ -11111,7 +11388,7 @@ normalize-html-whitespace@^1.0.0:
   resolved "https://registry.yarnpkg.com/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz#5e3c8e192f1b06c3b9eee4b7e7f28854c7601e34"
   integrity sha512-9ui7CGtOOlehQu0t/OhhlmDyc71mKVlv+4vF+me4iZLPrNtRL2xoquEdfZxasC/bdQi/Hr3iTrpyRKIG+ocabA==
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -11204,6 +11481,13 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npm-run-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
 
 npm-run-path@^4.0.0:
   version "4.0.0"
@@ -11439,6 +11723,11 @@ open@^6.4.0:
   dependencies:
     is-wsl "^1.1.0"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opentracing@^0.14.4:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.4.tgz#a113408ea740da3a90fde5b3b0011a375c2e4268"
@@ -11635,7 +11924,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
   integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
@@ -11655,6 +11944,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -12011,6 +12307,11 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -12191,6 +12492,20 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
+please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -12683,11 +12998,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
-
-prettier@^1.18.2:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^5.3.0:
   version "5.3.0"
@@ -13521,6 +13831,16 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
+
 read@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
@@ -13687,6 +14007,11 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -14072,7 +14397,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.5, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -14176,6 +14501,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
@@ -14200,7 +14530,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.4.0:
+rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
@@ -14386,6 +14716,11 @@ semaphore@^1.0.5, semaphore@^1.1.0:
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -14410,7 +14745,7 @@ semver-truncate@^1.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -14741,6 +15076,11 @@ slate@^0.34.0:
     slate-dev-logger "^0.1.39"
     slate-schema-violations "^0.1.20"
     type-of "^2.0.1"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 slice-ansi@^1.0.0:
   version "1.0.0"
@@ -15188,6 +15528,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
+string-argv@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -15304,6 +15649,15 @@ stringify-entities@^1.0.1:
     character-entities-legacy "^1.0.0"
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
+
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@3.0.1, strip-ansi@^3, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -15482,7 +15836,7 @@ svgo@1.3.2, svgo@^1.0.0, svgo@^1.3.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.2.0:
+symbol-observable@^1.0.2, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -15957,6 +16311,11 @@ type-fest@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -16890,6 +17249,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrap-ansi@^5.0.0, wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
**What:**
Similar to what we did at https://github.com/debtcollective/campaign-api/pull/11 the idea is to have a strong linting to help us with potential errors, besides, enforce to run the test before push branches in order to avoid cases like current one **where the test is failing in master branch**

**Why:**
We need to have a better linting configuration

**How:**
Keep approach at https://github.com/debtcollective/campaign-api/pull/11

**Note:**
This PR introduce a commit https://github.com/debtcollective/student-debt-campaign/commit/41a3a5d6cbe7bfc1cf5d5b05c4bdc61c5043e5bd that while is not ideal we need to keep this PR isolated to do its job **update linting and add needed configuration to prevent further corrupted state on master branch** the approach to prevent this problem has been described at https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-after-a-mutation and will be tackle with #46 

## Screenshots
N/A