### PR TITLE
Data Dues action front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,16 @@
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 .cache/
+
 # Build directory
 public/
 static/admin/*.bundle.*
 .DS_Store
 yarn-error.log
+
 # Env https://www.gatsbyjs.org/docs/environment-variables/
 .env.production
 .env.development
+
+# Test
+coverage

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-jsonschema-form": "2.0.0-alpha.1",
     "react-number-format": "4.3.1",
     "react-scroll": "1.7.14",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "yup": "0.27.0"
   },
   "keywords": [
     "gatsby"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-helmet": "^5.2.0",
     "react-hook-form": "3.28.2",
     "react-jsonschema-form": "2.0.0-alpha.1",
+    "react-number-format": "4.3.1",
     "react-scroll": "1.7.14",
     "uuid": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
+    "react-hook-form": "3.28.2",
     "react-jsonschema-form": "2.0.0-alpha.1",
     "react-scroll": "1.7.14",
     "uuid": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
+    "react-jsonschema-form": "2.0.0-alpha.1",
     "react-scroll": "1.7.14",
     "uuid": "^3.2.1"
   },

--- a/src/components/DataDuesAction/fields.js
+++ b/src/components/DataDuesAction/fields.js
@@ -20,7 +20,9 @@ export const PhoneNumberField = ({
       type="tel"
       placeholder="(202) 401-3000"
       customInput={Form.Control}
-      onValueChange={({ value }) => setValue(name, value, true)}
+      onValueChange={({ formattedValue, value }) => {
+        setValue(name, formattedValue || value, true)
+      }}
       format="(###) ###-####"
       mask="_"
       {...props}

--- a/src/components/DataDuesAction/fields.js
+++ b/src/components/DataDuesAction/fields.js
@@ -1,0 +1,107 @@
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import NumberFormat from 'react-number-format'
+import { Form } from 'react-bootstrap'
+
+export const PhoneNumberField = ({
+  name,
+  register,
+  unregister,
+  setValue,
+  ...props
+}) => {
+  useEffect(() => {
+    register({ name })
+    return () => unregister(name)
+  }, [name, register, unregister])
+
+  return (
+    <NumberFormat
+      type="tel"
+      placeholder="(202) 401-3000"
+      customInput={Form.Control}
+      onValueChange={({ value }) => setValue(name, value, true)}
+      format="(###) ###-####"
+      mask="_"
+      {...props}
+    />
+  )
+}
+
+PhoneNumberField.propTypes = {
+  name: PropTypes.string,
+  register: PropTypes.func,
+  unregister: PropTypes.func,
+  setValue: PropTypes.func
+}
+
+export const CurrencyField = ({
+  name,
+  register,
+  unregister,
+  setValue,
+  ...props
+}) => {
+  useEffect(() => {
+    register({ name, required: true })
+    return () => unregister(name)
+  }, [name, register, unregister])
+
+  return (
+    <NumberFormat
+      type="number"
+      placeholder="$38,000"
+      isNumericString={true}
+      onValueChange={({ value }) => setValue(name, value, true)}
+      customInput={Form.Control}
+      thousandSeparator={true}
+      allowNegative={false}
+      decimalScale={2}
+      prefix={'$'}
+      {...props}
+    />
+  )
+}
+
+CurrencyField.propTypes = {
+  name: PropTypes.string,
+  register: PropTypes.func,
+  unregister: PropTypes.func,
+  setValue: PropTypes.func
+}
+
+export const PercentageField = ({
+  name,
+  register,
+  unregister,
+  setValue,
+  ...props
+}) => {
+  useEffect(() => {
+    register({ name })
+    return () => unregister(name)
+  }, [name, register, unregister])
+
+  return (
+    <NumberFormat
+      placeholder="4.53%"
+      customInput={Form.Control}
+      onValueChange={({ value }) => setValue(name, value, true)}
+      thousandSeparator={false}
+      decimalScale={2}
+      suffix="%"
+      isAllowed={values => {
+        const { formattedValue, floatValue } = values
+        return formattedValue === '' || floatValue <= 100
+      }}
+      {...props}
+    />
+  )
+}
+
+PercentageField.propTypes = {
+  name: PropTypes.string,
+  register: PropTypes.func,
+  unregister: PropTypes.func,
+  setValue: PropTypes.func
+}

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,30 +1,101 @@
 import React from "react";
-import { Container, Row, Col, Form, Button } from "react-bootstrap";
+import { Container, Row, Col, Button } from "react-bootstrap";
+import Form from "react-jsonschema-form";
 
-const dataDuesSchema = {
+const schema = {
   type: "object",
   properties: {
     personalInformation: {
-      fullName: {
-        type: "string",
-        title: "Full name",
-        default: "Bernie Sanders"
-      },
-      email: {
-        type: "string",
-        title: "Email",
-        default: "Del Aguila"
-      },
-      streetAddress: {
-        type: "",
-        title: "Password",
-        minLength: 3
-      },
-      telephone: {
-        type: "string",
-        title: "Telephone",
-        minLength: 10
+      title: "Personal information",
+      type: "object",
+      required: ["fullName", "email"],
+      properties: {
+        fullName: {
+          type: "string",
+          title: "Full name"
+        },
+        email: {
+          type: "string",
+          format: "email",
+          title: "Email"
+        },
+        streetAddress: {
+          type: "string",
+          title: "Street address",
+          minLength: 3
+        },
+        phoneNumber: {
+          type: "string",
+          title: "Phone number",
+          pattern: "^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$",
+          minLength: 10
+        }
       }
+    },
+    debts: {
+      title: "Your Debts",
+      description:
+        "Please provide as much information about each account as you can.",
+      type: "object",
+      properties: {
+        debtType: {
+          type: "string",
+          title: "Debt type"
+        },
+        studentDebtType: {
+          type: "string",
+          format: "email",
+          title: "Student debt type"
+        },
+        amount: {
+          type: "string",
+          title: "Amount",
+          minLength: 3
+        },
+        interestRates: {
+          type: "string",
+          title: "Interest rates",
+          minLength: 3
+        },
+        creditor: {
+          type: "string",
+          title: "Creditor",
+          minLength: 10
+        },
+        accountStatus: {
+          type: "string",
+          title: "Account status",
+          minLength: 10
+        },
+        beingHarrased: {
+          type: "boolean",
+          enumNames: ["Yes", "No"],
+          title: "Are you being harrased by creditors or debt collectors?"
+        },
+        harrasmentDescription: {
+          type: "string",
+          title: "Describe the harrasment"
+        }
+      }
+    }
+  }
+};
+
+const uiSchema = {
+  personalInformation: {
+    fullName: {
+      "ui:placeholder": "Bernie Sanders"
+    },
+    email: {
+      "ui:placeholder": "bernie@berniesanders.com"
+    }
+  },
+  debts: {
+    beingHarrased: {
+      "ui:widget": "radio"
+    },
+    harrasmentDescription: {
+      "ui:widget": "textarea"
     }
   }
 };
@@ -54,7 +125,7 @@ const DataDuesAction = () => {
           </p>
         </Col>
       </Row>
-      <Form onSubmit={handleSubmit}>
+      <Form schema={schema} uiSchema={uiSchema} onSubmit={handleSubmit}>
         <div className="text-right">
           <Button variant="primary" type="submit">
             Save information

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { Container, Row, Col, Form, Button } from "react-bootstrap";
+
+const dataDuesSchema = {
+  type: "object",
+  properties: {
+    personalInformation: {
+      fullName: {
+        type: "string",
+        title: "Full name",
+        default: "Bernie Sanders"
+      },
+      email: {
+        type: "string",
+        title: "Email",
+        default: "Del Aguila"
+      },
+      streetAddress: {
+        type: "",
+        title: "Password",
+        minLength: 3
+      },
+      telephone: {
+        type: "string",
+        title: "Telephone",
+        minLength: 10
+      }
+    }
+  }
+};
+
+const DataDuesAction = () => {
+  const handleSubmit = event => {
+    event.preventDefault();
+  };
+
+  return (
+    <Container>
+      <Row>
+        <Col>
+          <h1 className="text-center">Data Dues</h1>
+        </Col>
+      </Row>
+      <Row className="mt-4">
+        <Col>
+          <p>
+            Thank you for offering your data to the Debt Collective. The more
+            info we have about the debts many of us have in common, the better
+            we can fight back together.
+          </p>
+          <p className="mt-2">
+            All information provided will be securely stored in our servers. We
+            won&apos;t share this information with corporations.
+          </p>
+        </Col>
+      </Row>
+      <Form onSubmit={handleSubmit}>
+        <div className="text-right">
+          <Button variant="primary" type="submit">
+            Save information
+          </Button>
+        </div>
+      </Form>
+    </Container>
+  );
+};
+
+export default DataDuesAction;

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -37,25 +37,41 @@ const schema = {
       description:
         "Please provide as much information about each account as you can.",
       type: "object",
+      required: ["debtType", "amount"],
       properties: {
         debtType: {
           type: "string",
-          title: "Debt type"
+          title: "Debt type",
+          enum: [
+            "Student debt",
+            "Housing debt",
+            "Medical debt",
+            "Court or bail fees",
+            "Payday loans",
+            "Auto loan",
+            "Credit card debt",
+            "Other"
+          ]
         },
         studentDebtType: {
           type: "string",
-          format: "email",
-          title: "Student debt type"
+          title: "Student debt type",
+          enum: [
+            "Subsidized Stafford",
+            "Unsubsidized Stafford",
+            "Parent PLUS",
+            "Private Student loans"
+          ]
         },
         amount: {
-          type: "string",
-          title: "Amount",
-          minLength: 3
+          type: "number",
+          title: "Amount"
         },
         interestRates: {
-          type: "string",
+          type: "number",
           title: "Interest rates",
-          minLength: 3
+          maxLength: 4,
+          minLength: 1
         },
         creditor: {
           type: "string",
@@ -65,7 +81,12 @@ const schema = {
         accountStatus: {
           type: "string",
           title: "Account status",
-          minLength: 10
+          enum: [
+            "In repayment",
+            "Late on payments",
+            "Stopped payments",
+            "Sent to collections"
+          ]
         },
         beingHarrased: {
           type: "boolean",
@@ -91,11 +112,21 @@ const uiSchema = {
     }
   },
   debts: {
+    debtType: {
+      "ui:placeholder": "Choose an option"
+    },
+    studentDebtType: {
+      "ui:placeholder": "Choose an option"
+    },
+    creditor: {
+      "ui:placeholder": "Sallie Mae"
+    },
     beingHarrased: {
       "ui:widget": "radio"
     },
     harrasmentDescription: {
-      "ui:widget": "textarea"
+      "ui:widget": "textarea",
+      "ui:placeholder": "They knock on my door everyday insulting me"
     }
   }
 };

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import useForm from 'react-hook-form'
+import { CurrencyField, PhoneNumberField, PercentageField } from './fields'
 import { Container, Row, Col, Button, Form } from 'react-bootstrap'
 
 const debtTypes = [
@@ -25,6 +26,7 @@ const accountStatus = [
   'Stopped payments',
   'Sent to collections'
 ]
+const unknown = 'Unknown'
 
 const DataDuesHeader = () => (
   <>
@@ -50,7 +52,6 @@ const DataDuesHeader = () => (
 )
 
 const DebtForm = ({ debtId, register, unregister, setValue, watch }) => {
-  const unknown = 'Unknown'
   const selectedDebtType = watch(`debts[${debtId}].debtType`)
   const isStudentDebt = selectedDebtType === 'Student debt'
 
@@ -128,11 +129,13 @@ const DebtForm = ({ debtId, register, unregister, setValue, watch }) => {
 
       <Form.Group controlId={`amount${debtId}`}>
         <Form.Label>Amount</Form.Label>
-        <Form.Control
+        <CurrencyField
           type="text"
-          placeholder="$38,000"
           name={`debts[${debtId}].amount`}
-          ref={register({ required: true })}
+          register={register}
+          unregister={unregister}
+          setValue={setValue}
+          required
         />
         <Form.Text className="text-muted">
           You don’t have to know the exact amount. A good guess is fine!
@@ -141,12 +144,13 @@ const DebtForm = ({ debtId, register, unregister, setValue, watch }) => {
 
       <Form.Group controlId={`interestRate${debtId}`}>
         <Form.Label>Interest rate</Form.Label>
-        <Form.Control
-          type="text"
-          placeholder="%5.5"
-          disabled={interestRateDisabled}
+        <PercentageField
           name={`debts[${debtId}].interestRate`}
-          ref={register}
+          register={register}
+          unregister={unregister}
+          setValue={setValue}
+          disabled={interestRateDisabled}
+          required
         />
         <Form.Check
           inline
@@ -291,7 +295,7 @@ const DataDuesForm = ({ onSubmit = data => console.log(data) }) => {
         <Form.Group controlId="email">
           <Form.Label>Email</Form.Label>
           <Form.Control
-            type="text"
+            type="email"
             placeholder="betsy.devos@ed.gov"
             name="email"
             ref={register({ required: true })}
@@ -310,11 +314,11 @@ const DataDuesForm = ({ onSubmit = data => console.log(data) }) => {
 
         <Form.Group controlId="phoneNumber">
           <Form.Label>Phone number</Form.Label>
-          <Form.Control
-            type="tel"
-            placeholder="(202) 401-3000"
+          <PhoneNumberField
             name="phoneNumber"
-            ref={register({ required: true })}
+            register={register}
+            unregister={unregister}
+            setValue={setValue}
           />
         </Form.Group>
       </div>

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -3,29 +3,6 @@ import PropTypes from 'prop-types'
 import useForm from 'react-hook-form'
 import { Container, Row, Col, Button, Form } from 'react-bootstrap'
 
-const DataDuesHeader = () => (
-  <>
-    <Row>
-      <Col>
-        <h1 className="text-center">Data Dues</h1>
-      </Col>
-    </Row>
-    <Row className="mt-4">
-      <Col>
-        <p>
-          Thank you for offering your data to the Debt Collective. The more info
-          we have about the debts many of us have in common, the better we can
-          fight back together.
-        </p>
-        <p className="mt-2">
-          All information provided will be securely stored in our servers. We
-          won&apos;t share this information with corporations.
-        </p>
-      </Col>
-    </Row>
-  </>
-)
-
 const debtTypes = [
   'Student debt',
   'Housing debt',
@@ -49,37 +26,99 @@ const accountStatus = [
   'Sent to collections'
 ]
 
-const DebtForm = ({ debtId, register, unregister, watch }) => {
-  // TODO: add default values
+const DataDuesHeader = () => (
+  <>
+    <Row>
+      <Col>
+        <h1 className="text-center">Data Dues</h1>
+      </Col>
+    </Row>
+    <Row className="mt-4">
+      <Col>
+        <p>
+          Thank you for offering your data to the Debt Collective. The more info
+          we have about the debts many of us have in common, the better we can
+          fight back together.
+        </p>
+        <p className="mt-2">
+          All information provided will be securely stored in our servers. We
+          won&apos;t share this information with corporations.
+        </p>
+      </Col>
+    </Row>
+  </>
+)
+
+const DebtForm = ({ debtId, register, unregister, setValue, watch }) => {
+  const unknown = 'Unknown'
   const selectedDebtType = watch(`debts[${debtId}].debtType`)
   const isStudentDebt = selectedDebtType === 'Student debt'
 
   const beingHarrasedOption = watch(`debts[${debtId}].beingHarrased`)
   const isBeingHarrased = beingHarrasedOption === 'Yes'
 
+  // onChange handler for "I don't know" checkboxes
+  const onChange = (name, setDisabled, event) => {
+    const isChecked = event.target.checked
+    const value = isChecked ? unknown : ''
+
+    setValue(name, value)
+    setDisabled(isChecked)
+  }
+
+  /**
+   * We are using the following states to programatically disable fields.
+   * These is used by fields that have a "I don't know" checkbox
+   */
+  const [debtTypeDisabled, setDebtTypeDisabled] = useState(false)
+  const [interestRateDisabled, setInterestRateDisabled] = useState(false)
+  const [creditorDisabled, setCreditorDisabled] = useState(false)
+  const [accountStatusDisabled, setAccountStatusDisabled] = useState(false)
+
   return (
     <>
-      <Form.Group controlId="debtType">
+      <Form.Group controlId={`debtType${debtId}`}>
         <Form.Label>Debt type</Form.Label>
         <Form.Control
           as="select"
           name={`debts[${debtId}].debtType`}
+          disabled={debtTypeDisabled}
+          defaultValue=""
           ref={register({ required: true })}
         >
+          <option value="" disabled hidden>
+            Select debt type
+          </option>
+          <option value={unknown} disabled hidden>
+            {unknown}
+          </option>
           {debtTypes.map(item => (
             <option key={item}>{item}</option>
           ))}
         </Form.Control>
+        <Form.Check
+          inline
+          onChange={event =>
+            onChange(`debts[${debtId}].debtType`, setDebtTypeDisabled, event)
+          }
+          type="checkbox"
+          id={`debtTypeUnknown${debtId}`}
+          label="I don't know my debt type"
+        />
       </Form.Group>
 
       {isStudentDebt && (
-        <Form.Group controlId="studentDebtType">
+        <Form.Group controlId={`studentDebtType${debtId}`}>
           <Form.Label>Student debt type</Form.Label>
           <Form.Control
             as="select"
             name={`debts[${debtId}].studentDebtType`}
+            defaultValue=""
             ref={register({ required: true })}
           >
+            <option value="" disabled hidden>
+              Select a student debt type
+            </option>
             {studentDebtType.map(item => (
               <option key={item}>{item}</option>
             ))}
@@ -87,7 +126,7 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
         </Form.Group>
       )}
 
-      <Form.Group controlId="amount">
+      <Form.Group controlId={`amount${debtId}`}>
         <Form.Label>Amount</Form.Label>
         <Form.Control
           type="text"
@@ -100,45 +139,65 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
         </Form.Text>
       </Form.Group>
 
-      <Form.Group controlId="interestRate">
+      <Form.Group controlId={`interestRate${debtId}`}>
         <Form.Label>Interest rate</Form.Label>
         <Form.Control
           type="text"
           placeholder="%5.5"
+          disabled={interestRateDisabled}
           name={`debts[${debtId}].interestRate`}
           ref={register}
         />
         <Form.Check
           inline
           type="checkbox"
-          id="interestRateUnknown"
+          id={`interestRateUnknown${debtId}`}
+          onChange={event =>
+            onChange(
+              `debts[${debtId}].interestRate`,
+              setInterestRateDisabled,
+              event
+            )
+          }
           label="I don't know my interest rate"
         />
       </Form.Group>
 
-      <Form.Group controlId="interestRate">
+      <Form.Group controlId={`interestRate${debtId}`}>
         <Form.Label>Creditor</Form.Label>
         <Form.Control
           type="text"
           placeholder="Sallie Mae"
+          disabled={creditorDisabled}
           name={`debts[${debtId}].creditor`}
           ref={register}
         />
         <Form.Check
           inline
           type="checkbox"
-          id="creditorUnknown"
+          id={`creditorUnknown${debtId}`}
+          onChange={event =>
+            onChange(`debts[${debtId}].creditor`, setCreditorDisabled, event)
+          }
           label="I don't know my creditor"
         />
       </Form.Group>
 
-      <Form.Group controlId="accountStatus">
+      <Form.Group controlId={`accountStatus${debtId}`}>
         <Form.Label>Account status</Form.Label>
         <Form.Control
           as="select"
           name={`debts[${debtId}].accountStatus`}
+          disabled={accountStatusDisabled}
+          defaultValue=""
           ref={register}
         >
+          <option value="" disabled hidden>
+            Select your account status
+          </option>
+          <option value={unknown} disabled hidden>
+            {unknown}
+          </option>
           {accountStatus.map(item => (
             <option key={item}>{item}</option>
           ))}
@@ -146,18 +205,25 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
         <Form.Check
           inline
           type="checkbox"
-          id="accountStatusUnknown"
+          id={`accountStatusUnknown${debtId}`}
+          onChange={event =>
+            onChange(
+              `debts[${debtId}].accountStatus`,
+              setAccountStatusDisabled,
+              event
+            )
+          }
           label="I don't know my account status"
         />
       </Form.Group>
 
-      <Form.Group controlId="beingHarrased">
+      <Form.Group controlId={`beingHarrased${debtId}`}>
         <Form.Label>
           Are you being harrased by creditors or debt collectors?
         </Form.Label>
         <Form.Check
           type="radio"
-          id="beingHarrasedYes"
+          id={`beingHarrasedYes${debtId}`}
           label="Yes"
           value="Yes"
           name={`debts[${debtId}].beingHarrased`}
@@ -165,7 +231,7 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
         />
         <Form.Check
           type="radio"
-          id="beingHarrasedNo"
+          id={`beingHarrasedNo${debtId}`}
           name={`debts[${debtId}].beingHarrased`}
           value="No"
           ref={register}
@@ -174,7 +240,7 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
       </Form.Group>
 
       {isBeingHarrased && (
-        <Form.Group controlId="harrasmentDescription">
+        <Form.Group controlId={`harrasmentDescription${debtId}`}>
           <Form.Label>Describe the harrasment</Form.Label>
           <Form.Control
             as="textarea"
@@ -190,14 +256,15 @@ const DebtForm = ({ debtId, register, unregister, watch }) => {
 }
 
 DebtForm.propTypes = {
-  debtId: PropTypes.string,
+  debtId: PropTypes.number,
   register: PropTypes.func,
   unregister: PropTypes.func,
+  setValue: PropTypes.func,
   watch: PropTypes.func
 }
 
 const DataDuesForm = ({ onSubmit = data => console.log(data) }) => {
-  const { register, handleSubmit, watch, unregister } = useForm()
+  const { register, handleSubmit, watch, setValue, unregister } = useForm()
   const [debts, setDebts] = useState([Date.now()])
 
   const addDebt = () => {
@@ -263,6 +330,7 @@ const DataDuesForm = ({ onSubmit = data => console.log(data) }) => {
               register={register}
               watch={watch}
               unregister={unregister}
+              setValue={setValue}
             />
           </>
         ))}

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,214 +1,206 @@
-import React from "react";
-import { Container, Row, Col, Button } from "react-bootstrap";
-import { withTheme } from "react-jsonschema-form";
-import { Theme as MuiTheme } from "rjsf-material-ui";
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Container, Row, Col, Button, Form } from 'react-bootstrap'
 
-const Form = withTheme(MuiTheme);
+const DataDuesHeader = () => (
+  <>
+    <Row>
+      <Col>
+        <h1 className="text-center">Data Dues</h1>
+      </Col>
+    </Row>
+    <Row className="mt-4">
+      <Col>
+        <p>
+          Thank you for offering your data to the Debt Collective. The more info
+          we have about the debts many of us have in common, the better we can
+          fight back together.
+        </p>
+        <p className="mt-2">
+          All information provided will be securely stored in our servers. We
+          won&apos;t share this information with corporations.
+        </p>
+      </Col>
+    </Row>
+  </>
+)
 
-const schema = {
-  definitions: {
-    debt: {
-      type: "object",
-      properties: {
-        debtType: {
-          type: "string",
-          title: "Debt type",
-          enum: [
-            "Student debt",
-            "Housing debt",
-            "Medical debt",
-            "Court or bail fees",
-            "Payday loans",
-            "Auto loan",
-            "Credit card debt",
-            "Other"
-          ]
-        },
-        amount: {
-          type: "number",
-          title: "Amount"
-        },
-        interestRate: {
-          type: "number",
-          title: "Interest rate",
-          maxLength: 4,
-          minLength: 1
-        },
-        creditor: {
-          type: "string",
-          title: "Creditor",
-          minLength: 10
-        },
-        accountStatus: {
-          type: "string",
-          title: "Account status",
-          enum: [
-            "In repayment",
-            "Late on payments",
-            "Stopped payments",
-            "Sent to collections"
-          ]
-        },
-        beingHarrased: {
-          type: "boolean",
-          enumNames: ["Yes", "No"],
-          title: "Are you being harrased by creditors or debt collectors?"
-        },
-        harrasmentDescription: {
-          type: "string",
-          title: "Describe the harrasment"
-        }
-      },
-      required: ["debtType", "amount", "beingHarrased"],
-      dependencies: {
-        debtType: {
-          oneOf: [
-            {
-              properties: {
-                debtType: {
-                  enum: ["Student debt"]
-                },
-                studentDebtType: {
-                  type: "string",
-                  title: "Student debt type",
-                  enum: [
-                    "Subsidized Stafford",
-                    "Unsubsidized Stafford",
-                    "Parent PLUS",
-                    "Private Student loans"
-                  ]
-                }
-              },
-              required: ["studentDebtType"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  type: "object",
-  properties: {
-    personalInformation: {
-      title: "Personal information",
-      type: "object",
-      required: ["fullName", "email"],
-      properties: {
-        fullName: {
-          type: "string",
-          title: "Full name"
-        },
-        email: {
-          type: "string",
-          format: "email",
-          title: "Email"
-        },
-        streetAddress: {
-          type: "string",
-          title: "Street address",
-          minLength: 3
-        },
-        phoneNumber: {
-          type: "string",
-          title: "Phone number",
-          pattern: "^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$",
-          minLength: 10
-        }
-      }
-    },
-    debts: {
-      title: "Your Debts",
-      description:
-        "Please provide as much information about each account as you can.",
-      type: "array",
-      items: [
-        {
-          $ref: "#/definitions/debt"
-        }
-      ],
-      additionalItems: {
-        $ref: "#/definitions/debt"
-      }
-    }
-  }
-};
+const DataDuesForm = ({ handleSubmit }) => {
+  const debtTypes = [
+    'Student debt',
+    'Housing debt',
+    'Medical debt',
+    'Court or bail fees',
+    'Payday loans',
+    'Auto loan',
+    'Credit card debt',
+    'Other'
+  ]
+  const studentDebtType = [
+    'Subsidized Stafford',
+    'Unsubsidized Stafford',
+    'Parent PLUS',
+    'Private Student loans'
+  ]
+  const accountStatus = [
+    'In repayment',
+    'Late on payments',
+    'Stopped payments',
+    'Sent to collections'
+  ]
 
-const uiSchema = {
-  personalInformation: {
-    fullName: {
-      "ui:placeholder": "Bernie Sanders"
-    },
-    email: {
-      "ui:placeholder": "bernie@berniesanders.com"
-    }
-  },
-  debts: {
-    items: [
-      {
-        "ui:order": [
-          "debtType",
-          "studentDebtType",
-          "amount",
-          "interestRate",
-          "creditor",
-          "accountStatus",
-          "beingHarrased",
-          "harrasmentDescription"
-        ],
-        debtType: {
-          "ui:placeholder": "Choose an option"
-        },
-        studentDebtType: {
-          "ui:placeholder": "Choose an option"
-        },
-        creditor: {
-          "ui:placeholder": "Sallie Mae"
-        },
-        beingHarrased: {
-          "ui:widget": "radio"
-        },
-        harrasmentDescription: {
-          "ui:widget": "textarea",
-          "ui:placeholder": "They knock on my door everyday insulting me"
-        }
-      }
-    ]
-  }
-};
+  return (
+    <Form onSubmit={handleSubmit}>
+      <div className="mt-4">
+        <h3>Personal information</h3>
+        <Form.Group controlId="fullName">
+          <Form.Label>Full name</Form.Label>
+          <Form.Control type="text" placeholder="Betsy DeVos" />
+        </Form.Group>
+
+        <Form.Group controlId="email">
+          <Form.Label>Email</Form.Label>
+          <Form.Control type="text" placeholder="betsy.devos@ed.gov" />
+        </Form.Group>
+
+        <Form.Group controlId="streetAddress">
+          <Form.Label>Street address</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder="400 Maryland Avenue, SW. Washington, DC 20202"
+          />
+        </Form.Group>
+
+        <Form.Group controlId="phoneNumber">
+          <Form.Label>Phone number</Form.Label>
+          <Form.Control type="tel" placeholder="(202) 401-3000" />
+        </Form.Group>
+      </div>
+
+      <div className="mt-4">
+        <h3>Your debts</h3>
+        <Form.Group controlId="debtType">
+          <Form.Label>Debt type</Form.Label>
+          <Form.Control as="select">
+            {debtTypes.map(item => (
+              <option key={item}>{item}</option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group controlId="studentDebtType">
+          <Form.Label>Student debt type</Form.Label>
+          <Form.Control as="select">
+            {studentDebtType.map(item => (
+              <option key={item}>{item}</option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group controlId="amount">
+          <Form.Label>Amount</Form.Label>
+          <Form.Control type="text" placeholder="$38,000" />
+          <Form.Text className="text-muted">
+            You don’t have to know the exact amount. A good guess is fine!
+          </Form.Text>
+        </Form.Group>
+
+        <Form.Group controlId="interestRate">
+          <Form.Label>Interest rate</Form.Label>
+          <Form.Control type="text" placeholder="%5.5" />
+          <Form.Check
+            inline
+            type="checkbox"
+            id="interestRateUnknown"
+            label="I don't know my interest rate"
+          />
+        </Form.Group>
+
+        <Form.Group controlId="interestRate">
+          <Form.Label>Creditor</Form.Label>
+          <Form.Control type="text" placeholder="Sallie Mae" />
+          <Form.Check
+            inline
+            type="checkbox"
+            id="creditorUnknown"
+            label="I don't know my creditor"
+          />
+        </Form.Group>
+
+        <Form.Group controlId="accountStatus">
+          <Form.Label>Account status</Form.Label>
+          <Form.Control as="select">
+            {accountStatus.map(item => (
+              <option key={item}>{item}</option>
+            ))}
+          </Form.Control>
+          <Form.Check
+            inline
+            type="checkbox"
+            id="accountStatusUnknown"
+            label="I don't know my account status"
+          />
+        </Form.Group>
+
+        <Form.Group controlId="beingHarrased">
+          <Form.Label>
+            Are you being harrased by creditors or debt collectors?
+          </Form.Label>
+          <Form.Check
+            custom
+            name="beingHarrased"
+            type="radio"
+            id="beingHarrasedYes"
+            label="Yes"
+          />
+          <Form.Check
+            custom
+            name="beingHarrased"
+            type="radio"
+            id="beingHarrasedNo"
+            label="No"
+          />
+        </Form.Group>
+
+        <Form.Group controlId="harrasmentDescription">
+          <Form.Label>Describe the harrasment</Form.Label>
+          <Form.Control
+            as="textarea"
+            name="harrasmentDescription"
+            rows="3"
+            placeholder="Debt collectors knock everyday on my door asking for money"
+          />
+        </Form.Group>
+
+        <div>
+          <Button variant="secondary">+ Add another debt</Button>
+        </div>
+      </div>
+
+      <div className="text-right">
+        <Button variant="primary" type="submit">
+          Save information
+        </Button>
+      </div>
+    </Form>
+  )
+}
+
+DataDuesForm.propTypes = {
+  handleSubmit: PropTypes.func
+}
 
 const DataDuesAction = () => {
   const handleSubmit = event => {
-    event.preventDefault();
-  };
+    event.preventDefault()
+  }
 
   return (
     <Container>
-      <Row>
-        <Col>
-          <h1 className="text-center">Data Dues</h1>
-        </Col>
-      </Row>
-      <Row className="mt-4">
-        <Col>
-          <p>
-            Thank you for offering your data to the Debt Collective. The more
-            info we have about the debts many of us have in common, the better
-            we can fight back together.
-          </p>
-          <p className="mt-2">
-            All information provided will be securely stored in our servers. We
-            won&apos;t share this information with corporations.
-          </p>
-        </Col>
-      </Row>
-      <Form schema={schema} uiSchema={uiSchema} onSubmit={handleSubmit}>
-        <div className="text-right">
-          <Button variant="primary" type="submit">
-            Save information
-          </Button>
-        </div>
-      </Form>
+      <DataDuesHeader />
+      <DataDuesForm handleSubmit={handleSubmit} />
     </Container>
-  );
-};
+  )
+}
 
-export default DataDuesAction;
+export default DataDuesAction

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,8 +1,91 @@
 import React from "react";
 import { Container, Row, Col, Button } from "react-bootstrap";
-import Form from "react-jsonschema-form";
+import { withTheme } from "react-jsonschema-form";
+import { Theme as MuiTheme } from "rjsf-material-ui";
+
+const Form = withTheme(MuiTheme);
 
 const schema = {
+  definitions: {
+    debt: {
+      type: "object",
+      properties: {
+        debtType: {
+          type: "string",
+          title: "Debt type",
+          enum: [
+            "Student debt",
+            "Housing debt",
+            "Medical debt",
+            "Court or bail fees",
+            "Payday loans",
+            "Auto loan",
+            "Credit card debt",
+            "Other"
+          ]
+        },
+        amount: {
+          type: "number",
+          title: "Amount"
+        },
+        interestRate: {
+          type: "number",
+          title: "Interest rate",
+          maxLength: 4,
+          minLength: 1
+        },
+        creditor: {
+          type: "string",
+          title: "Creditor",
+          minLength: 10
+        },
+        accountStatus: {
+          type: "string",
+          title: "Account status",
+          enum: [
+            "In repayment",
+            "Late on payments",
+            "Stopped payments",
+            "Sent to collections"
+          ]
+        },
+        beingHarrased: {
+          type: "boolean",
+          enumNames: ["Yes", "No"],
+          title: "Are you being harrased by creditors or debt collectors?"
+        },
+        harrasmentDescription: {
+          type: "string",
+          title: "Describe the harrasment"
+        }
+      },
+      required: ["debtType", "amount", "beingHarrased"],
+      dependencies: {
+        debtType: {
+          oneOf: [
+            {
+              properties: {
+                debtType: {
+                  enum: ["Student debt"]
+                },
+                studentDebtType: {
+                  type: "string",
+                  title: "Student debt type",
+                  enum: [
+                    "Subsidized Stafford",
+                    "Unsubsidized Stafford",
+                    "Parent PLUS",
+                    "Private Student loans"
+                  ]
+                }
+              },
+              required: ["studentDebtType"]
+            }
+          ]
+        }
+      }
+    }
+  },
   type: "object",
   properties: {
     personalInformation: {
@@ -36,67 +119,14 @@ const schema = {
       title: "Your Debts",
       description:
         "Please provide as much information about each account as you can.",
-      type: "object",
-      required: ["debtType", "amount"],
-      properties: {
-        debtType: {
-          type: "string",
-          title: "Debt type",
-          enum: [
-            "Student debt",
-            "Housing debt",
-            "Medical debt",
-            "Court or bail fees",
-            "Payday loans",
-            "Auto loan",
-            "Credit card debt",
-            "Other"
-          ]
-        },
-        studentDebtType: {
-          type: "string",
-          title: "Student debt type",
-          enum: [
-            "Subsidized Stafford",
-            "Unsubsidized Stafford",
-            "Parent PLUS",
-            "Private Student loans"
-          ]
-        },
-        amount: {
-          type: "number",
-          title: "Amount"
-        },
-        interestRates: {
-          type: "number",
-          title: "Interest rates",
-          maxLength: 4,
-          minLength: 1
-        },
-        creditor: {
-          type: "string",
-          title: "Creditor",
-          minLength: 10
-        },
-        accountStatus: {
-          type: "string",
-          title: "Account status",
-          enum: [
-            "In repayment",
-            "Late on payments",
-            "Stopped payments",
-            "Sent to collections"
-          ]
-        },
-        beingHarrased: {
-          type: "boolean",
-          enumNames: ["Yes", "No"],
-          title: "Are you being harrased by creditors or debt collectors?"
-        },
-        harrasmentDescription: {
-          type: "string",
-          title: "Describe the harrasment"
+      type: "array",
+      items: [
+        {
+          $ref: "#/definitions/debt"
         }
+      ],
+      additionalItems: {
+        $ref: "#/definitions/debt"
       }
     }
   }
@@ -112,22 +142,36 @@ const uiSchema = {
     }
   },
   debts: {
-    debtType: {
-      "ui:placeholder": "Choose an option"
-    },
-    studentDebtType: {
-      "ui:placeholder": "Choose an option"
-    },
-    creditor: {
-      "ui:placeholder": "Sallie Mae"
-    },
-    beingHarrased: {
-      "ui:widget": "radio"
-    },
-    harrasmentDescription: {
-      "ui:widget": "textarea",
-      "ui:placeholder": "They knock on my door everyday insulting me"
-    }
+    items: [
+      {
+        "ui:order": [
+          "debtType",
+          "studentDebtType",
+          "amount",
+          "interestRate",
+          "creditor",
+          "accountStatus",
+          "beingHarrased",
+          "harrasmentDescription"
+        ],
+        debtType: {
+          "ui:placeholder": "Choose an option"
+        },
+        studentDebtType: {
+          "ui:placeholder": "Choose an option"
+        },
+        creditor: {
+          "ui:placeholder": "Sallie Mae"
+        },
+        beingHarrased: {
+          "ui:widget": "radio"
+        },
+        harrasmentDescription: {
+          "ui:widget": "textarea",
+          "ui:placeholder": "They knock on my door everyday insulting me"
+        }
+      }
+    ]
   }
 };
 

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import useForm from 'react-hook-form'
 import { Container, Row, Col, Button, Form } from 'react-bootstrap'
 
 const DataDuesHeader = () => (
@@ -25,42 +26,209 @@ const DataDuesHeader = () => (
   </>
 )
 
-const DataDuesForm = ({ handleSubmit }) => {
-  const debtTypes = [
-    'Student debt',
-    'Housing debt',
-    'Medical debt',
-    'Court or bail fees',
-    'Payday loans',
-    'Auto loan',
-    'Credit card debt',
-    'Other'
-  ]
-  const studentDebtType = [
-    'Subsidized Stafford',
-    'Unsubsidized Stafford',
-    'Parent PLUS',
-    'Private Student loans'
-  ]
-  const accountStatus = [
-    'In repayment',
-    'Late on payments',
-    'Stopped payments',
-    'Sent to collections'
-  ]
+const debtTypes = [
+  'Student debt',
+  'Housing debt',
+  'Medical debt',
+  'Court or bail fees',
+  'Payday loans',
+  'Auto loan',
+  'Credit card debt',
+  'Other'
+]
+const studentDebtType = [
+  'Subsidized Stafford',
+  'Unsubsidized Stafford',
+  'Parent PLUS',
+  'Private Student loans'
+]
+const accountStatus = [
+  'In repayment',
+  'Late on payments',
+  'Stopped payments',
+  'Sent to collections'
+]
+
+const DebtForm = ({ debtId, register, unregister, watch }) => {
+  // TODO: add default values
+  const selectedDebtType = watch(`debts[${debtId}].debtType`)
+  const isStudentDebt = selectedDebtType === 'Student debt'
+
+  const beingHarrasedOption = watch(`debts[${debtId}].beingHarrased`)
+  const isBeingHarrased = beingHarrasedOption === 'Yes'
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <>
+      <Form.Group controlId="debtType">
+        <Form.Label>Debt type</Form.Label>
+        <Form.Control
+          as="select"
+          name={`debts[${debtId}].debtType`}
+          ref={register({ required: true })}
+        >
+          {debtTypes.map(item => (
+            <option key={item}>{item}</option>
+          ))}
+        </Form.Control>
+      </Form.Group>
+
+      {isStudentDebt && (
+        <Form.Group controlId="studentDebtType">
+          <Form.Label>Student debt type</Form.Label>
+          <Form.Control
+            as="select"
+            name={`debts[${debtId}].studentDebtType`}
+            ref={register({ required: true })}
+          >
+            {studentDebtType.map(item => (
+              <option key={item}>{item}</option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+      )}
+
+      <Form.Group controlId="amount">
+        <Form.Label>Amount</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="$38,000"
+          name={`debts[${debtId}].amount`}
+          ref={register({ required: true })}
+        />
+        <Form.Text className="text-muted">
+          You don’t have to know the exact amount. A good guess is fine!
+        </Form.Text>
+      </Form.Group>
+
+      <Form.Group controlId="interestRate">
+        <Form.Label>Interest rate</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="%5.5"
+          name={`debts[${debtId}].interestRate`}
+          ref={register}
+        />
+        <Form.Check
+          inline
+          type="checkbox"
+          id="interestRateUnknown"
+          label="I don't know my interest rate"
+        />
+      </Form.Group>
+
+      <Form.Group controlId="interestRate">
+        <Form.Label>Creditor</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="Sallie Mae"
+          name={`debts[${debtId}].creditor`}
+          ref={register}
+        />
+        <Form.Check
+          inline
+          type="checkbox"
+          id="creditorUnknown"
+          label="I don't know my creditor"
+        />
+      </Form.Group>
+
+      <Form.Group controlId="accountStatus">
+        <Form.Label>Account status</Form.Label>
+        <Form.Control
+          as="select"
+          name={`debts[${debtId}].accountStatus`}
+          ref={register}
+        >
+          {accountStatus.map(item => (
+            <option key={item}>{item}</option>
+          ))}
+        </Form.Control>
+        <Form.Check
+          inline
+          type="checkbox"
+          id="accountStatusUnknown"
+          label="I don't know my account status"
+        />
+      </Form.Group>
+
+      <Form.Group controlId="beingHarrased">
+        <Form.Label>
+          Are you being harrased by creditors or debt collectors?
+        </Form.Label>
+        <Form.Check
+          type="radio"
+          id="beingHarrasedYes"
+          label="Yes"
+          value="Yes"
+          name={`debts[${debtId}].beingHarrased`}
+          ref={register}
+        />
+        <Form.Check
+          type="radio"
+          id="beingHarrasedNo"
+          name={`debts[${debtId}].beingHarrased`}
+          value="No"
+          ref={register}
+          label="No"
+        />
+      </Form.Group>
+
+      {isBeingHarrased && (
+        <Form.Group controlId="harrasmentDescription">
+          <Form.Label>Describe the harrasment</Form.Label>
+          <Form.Control
+            as="textarea"
+            rows="3"
+            name={`debts[${debtId}].harrasmentDescription`}
+            ref={register}
+            placeholder="Debt collectors knock everyday on my door asking for money"
+          />
+        </Form.Group>
+      )}
+    </>
+  )
+}
+
+DebtForm.propTypes = {
+  debtId: PropTypes.string,
+  register: PropTypes.func,
+  unregister: PropTypes.func,
+  watch: PropTypes.func
+}
+
+const DataDuesForm = ({ onSubmit = data => console.log(data) }) => {
+  const { register, handleSubmit, watch, unregister } = useForm()
+  const [debts, setDebts] = useState([Date.now()])
+
+  const addDebt = () => {
+    // This will give us pseudo unique values
+    // Better than using an index
+    const debtId = Date.now()
+    setDebts([...debts, debtId])
+  }
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
       <div className="mt-4">
         <h3>Personal information</h3>
         <Form.Group controlId="fullName">
           <Form.Label>Full name</Form.Label>
-          <Form.Control type="text" placeholder="Betsy DeVos" />
+          <Form.Control
+            type="text"
+            name="fullName"
+            placeholder="Betsy DeVos"
+            ref={register({ required: true })}
+          />
         </Form.Group>
 
         <Form.Group controlId="email">
           <Form.Label>Email</Form.Label>
-          <Form.Control type="text" placeholder="betsy.devos@ed.gov" />
+          <Form.Control
+            type="text"
+            placeholder="betsy.devos@ed.gov"
+            name="email"
+            ref={register({ required: true })}
+          />
         </Form.Group>
 
         <Form.Group controlId="streetAddress">
@@ -68,112 +236,40 @@ const DataDuesForm = ({ handleSubmit }) => {
           <Form.Control
             type="text"
             placeholder="400 Maryland Avenue, SW. Washington, DC 20202"
+            name="streetAddress"
+            ref={register({ required: true })}
           />
         </Form.Group>
 
         <Form.Group controlId="phoneNumber">
           <Form.Label>Phone number</Form.Label>
-          <Form.Control type="tel" placeholder="(202) 401-3000" />
+          <Form.Control
+            type="tel"
+            placeholder="(202) 401-3000"
+            name="phoneNumber"
+            ref={register({ required: true })}
+          />
         </Form.Group>
       </div>
 
       <div className="mt-4">
         <h3>Your debts</h3>
-        <Form.Group controlId="debtType">
-          <Form.Label>Debt type</Form.Label>
-          <Form.Control as="select">
-            {debtTypes.map(item => (
-              <option key={item}>{item}</option>
-            ))}
-          </Form.Control>
-        </Form.Group>
-
-        <Form.Group controlId="studentDebtType">
-          <Form.Label>Student debt type</Form.Label>
-          <Form.Control as="select">
-            {studentDebtType.map(item => (
-              <option key={item}>{item}</option>
-            ))}
-          </Form.Control>
-        </Form.Group>
-
-        <Form.Group controlId="amount">
-          <Form.Label>Amount</Form.Label>
-          <Form.Control type="text" placeholder="$38,000" />
-          <Form.Text className="text-muted">
-            You don’t have to know the exact amount. A good guess is fine!
-          </Form.Text>
-        </Form.Group>
-
-        <Form.Group controlId="interestRate">
-          <Form.Label>Interest rate</Form.Label>
-          <Form.Control type="text" placeholder="%5.5" />
-          <Form.Check
-            inline
-            type="checkbox"
-            id="interestRateUnknown"
-            label="I don't know my interest rate"
-          />
-        </Form.Group>
-
-        <Form.Group controlId="interestRate">
-          <Form.Label>Creditor</Form.Label>
-          <Form.Control type="text" placeholder="Sallie Mae" />
-          <Form.Check
-            inline
-            type="checkbox"
-            id="creditorUnknown"
-            label="I don't know my creditor"
-          />
-        </Form.Group>
-
-        <Form.Group controlId="accountStatus">
-          <Form.Label>Account status</Form.Label>
-          <Form.Control as="select">
-            {accountStatus.map(item => (
-              <option key={item}>{item}</option>
-            ))}
-          </Form.Control>
-          <Form.Check
-            inline
-            type="checkbox"
-            id="accountStatusUnknown"
-            label="I don't know my account status"
-          />
-        </Form.Group>
-
-        <Form.Group controlId="beingHarrased">
-          <Form.Label>
-            Are you being harrased by creditors or debt collectors?
-          </Form.Label>
-          <Form.Check
-            custom
-            name="beingHarrased"
-            type="radio"
-            id="beingHarrasedYes"
-            label="Yes"
-          />
-          <Form.Check
-            custom
-            name="beingHarrased"
-            type="radio"
-            id="beingHarrasedNo"
-            label="No"
-          />
-        </Form.Group>
-
-        <Form.Group controlId="harrasmentDescription">
-          <Form.Label>Describe the harrasment</Form.Label>
-          <Form.Control
-            as="textarea"
-            name="harrasmentDescription"
-            rows="3"
-            placeholder="Debt collectors knock everyday on my door asking for money"
-          />
-        </Form.Group>
-
+        {debts.map((debtId, index) => (
+          <>
+            {index > 0 && <hr />}
+            <DebtForm
+              debtId={debtId}
+              key={debtId}
+              register={register}
+              watch={watch}
+              unregister={unregister}
+            />
+          </>
+        ))}
         <div>
-          <Button variant="secondary">+ Add another debt</Button>
+          <Button variant="secondary" onClick={addDebt}>
+            + Add another debt
+          </Button>
         </div>
       </div>
 
@@ -187,7 +283,7 @@ const DataDuesForm = ({ handleSubmit }) => {
 }
 
 DataDuesForm.propTypes = {
-  handleSubmit: PropTypes.func
+  onSubmit: PropTypes.func
 }
 
 const DataDuesAction = () => {

--- a/src/components/DataDuesAction/schema.js
+++ b/src/components/DataDuesAction/schema.js
@@ -1,0 +1,128 @@
+const schema = {
+  definitions: {
+    debt: {
+      type: 'object',
+      properties: {
+        debtType: {
+          type: 'string',
+          title: 'Debt type',
+          enum: [
+            'Student debt',
+            'Housing debt',
+            'Medical debt',
+            'Court or bail fees',
+            'Payday loans',
+            'Auto loan',
+            'Credit card debt',
+            'Other'
+          ]
+        },
+        amount: {
+          type: 'number',
+          title: 'Amount'
+        },
+        interestRate: {
+          type: 'number',
+          title: 'Interest rate',
+          maxLength: 4,
+          minLength: 1
+        },
+        creditor: {
+          type: 'string',
+          title: 'Creditor',
+          minLength: 10
+        },
+        accountStatus: {
+          type: 'string',
+          title: 'Account status',
+          enum: [
+            'In repayment',
+            'Late on payments',
+            'Stopped payments',
+            'Sent to collections'
+          ]
+        },
+        beingHarrased: {
+          type: 'boolean',
+          enumNames: ['Yes', 'No'],
+          title: 'Are you being harrased by creditors or debt collectors?'
+        },
+        harrasmentDescription: {
+          type: 'string',
+          title: 'Describe the harrasment'
+        }
+      },
+      required: ['debtType', 'amount', 'beingHarrased'],
+      dependencies: {
+        debtType: {
+          oneOf: [
+            {
+              properties: {
+                debtType: {
+                  enum: ['Student debt']
+                },
+                studentDebtType: {
+                  type: 'string',
+                  title: 'Student debt type',
+                  enum: [
+                    'Subsidized Stafford',
+                    'Unsubsidized Stafford',
+                    'Parent PLUS',
+                    'Private Student loans'
+                  ]
+                }
+              },
+              required: ['studentDebtType']
+            }
+          ]
+        }
+      }
+    }
+  },
+  type: 'object',
+  properties: {
+    personalInformation: {
+      title: 'Personal information',
+      type: 'object',
+      required: ['fullName', 'email'],
+      properties: {
+        fullName: {
+          type: 'string',
+          title: 'Full name'
+        },
+        email: {
+          type: 'string',
+          format: 'email',
+          title: 'Email'
+        },
+        streetAddress: {
+          type: 'string',
+          title: 'Street address',
+          minLength: 3
+        },
+        phoneNumber: {
+          type: 'string',
+          title: 'Phone number',
+          pattern: '^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$',
+          minLength: 10
+        }
+      }
+    },
+    debts: {
+      title: 'Your Debts',
+      description:
+        'Please provide as much information about each account as you can.',
+      type: 'array',
+      items: [
+        {
+          $ref: '#/definitions/debt'
+        }
+      ],
+      additionalItems: {
+        $ref: '#/definitions/debt'
+      }
+    }
+  }
+}
+
+export default schema

--- a/src/components/DataDuesAction/schema.js
+++ b/src/components/DataDuesAction/schema.js
@@ -1,128 +1,61 @@
-const schema = {
-  definitions: {
-    debt: {
-      type: 'object',
-      properties: {
-        debtType: {
-          type: 'string',
-          title: 'Debt type',
-          enum: [
-            'Student debt',
-            'Housing debt',
-            'Medical debt',
-            'Court or bail fees',
-            'Payday loans',
-            'Auto loan',
-            'Credit card debt',
-            'Other'
-          ]
-        },
-        amount: {
-          type: 'number',
-          title: 'Amount'
-        },
-        interestRate: {
-          type: 'number',
-          title: 'Interest rate',
-          maxLength: 4,
-          minLength: 1
-        },
-        creditor: {
-          type: 'string',
-          title: 'Creditor',
-          minLength: 10
-        },
-        accountStatus: {
-          type: 'string',
-          title: 'Account status',
-          enum: [
-            'In repayment',
-            'Late on payments',
-            'Stopped payments',
-            'Sent to collections'
-          ]
-        },
-        beingHarrased: {
-          type: 'boolean',
-          enumNames: ['Yes', 'No'],
-          title: 'Are you being harrased by creditors or debt collectors?'
-        },
-        harrasmentDescription: {
-          type: 'string',
-          title: 'Describe the harrasment'
-        }
-      },
-      required: ['debtType', 'amount', 'beingHarrased'],
-      dependencies: {
-        debtType: {
-          oneOf: [
-            {
-              properties: {
-                debtType: {
-                  enum: ['Student debt']
-                },
-                studentDebtType: {
-                  type: 'string',
-                  title: 'Student debt type',
-                  enum: [
-                    'Subsidized Stafford',
-                    'Unsubsidized Stafford',
-                    'Parent PLUS',
-                    'Private Student loans'
-                  ]
-                }
-              },
-              required: ['studentDebtType']
-            }
-          ]
-        }
-      }
-    }
-  },
-  type: 'object',
-  properties: {
-    personalInformation: {
-      title: 'Personal information',
-      type: 'object',
-      required: ['fullName', 'email'],
-      properties: {
-        fullName: {
-          type: 'string',
-          title: 'Full name'
-        },
-        email: {
-          type: 'string',
-          format: 'email',
-          title: 'Email'
-        },
-        streetAddress: {
-          type: 'string',
-          title: 'Street address',
-          minLength: 3
-        },
-        phoneNumber: {
-          type: 'string',
-          title: 'Phone number',
-          pattern: '^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$',
-          minLength: 10
-        }
-      }
-    },
-    debts: {
-      title: 'Your Debts',
-      description:
-        'Please provide as much information about each account as you can.',
-      type: 'array',
-      items: [
-        {
-          $ref: '#/definitions/debt'
-        }
-      ],
-      additionalItems: {
-        $ref: '#/definitions/debt'
-      }
-    }
-  }
-}
+import * as yup from 'yup'
 
-export default schema
+export const debtTypes = [
+  'Student debt',
+  'Housing debt',
+  'Medical debt',
+  'Court or bail fees',
+  'Payday loans',
+  'Auto loan',
+  'Credit card debt',
+  'Other'
+]
+export const studentDebtTypes = [
+  'Subsidized Stafford',
+  'Unsubsidized Stafford',
+  'Parent PLUS',
+  'Private Student loans'
+]
+export const accountStatuses = [
+  'In repayment',
+  'Late on payments',
+  'Stopped payments',
+  'Sent to collections'
+]
+
+export const unknown = 'Unknown'
+
+const phoneRegExp = /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/
+
+export const validationSchema = yup.object().shape({
+  fullName: yup
+    .string()
+    .min(5, 'Full name must be at least ${min} characters') // eslint-disable-line no-template-curly-in-string
+    .required('Full name is a required field'),
+  email: yup
+    .string()
+    .email('Must be a valid email')
+    .required('Email is a required field'),
+  streetAddress: yup.string(),
+  phoneNumber: yup.string().matches(phoneRegExp, {
+    message: 'Phone number must be valid',
+    excludeEmptyString: true
+  }),
+  debts: yup.array().of(
+    yup.object().shape({
+      debtType: yup
+        .mixed()
+        .oneOf([...debtTypes, unknown], 'Debt type is required'),
+      studentDebtType: yup
+        .mixed()
+        .oneOf([...studentDebtTypes, unknown], 'Student debt type is required'),
+      amount: yup.number().required('Amount is required'),
+      interestRate: yup.string().required('Interest rate is required'),
+      creditor: yup.string().required('Creditor is required'),
+      accountStatus: yup
+        .mixed()
+        .oneOf([...accountStatuses, unknown], 'Account status is required'),
+      beingHarrased: yup.string().required('You need to answer this question')
+    })
+  )
+})

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -106,7 +106,7 @@ const Header = ({ user }) => {
                 <div className="d-none d-xl-flex">
                   <ul className="nav align-items-center" role="navigation">
                     <li className="nav-item">
-                      <Link to="#faq" className="nav-link">
+                      <Link to="/#faq" className="nav-link">
                         FAQ
                       </Link>
                     </li>
@@ -166,7 +166,7 @@ const Header = ({ user }) => {
         <div id="slider-nav" className="slider-nav d-xl-none">
           <ul className="nav flex-column" role="navigation">
             <li className="nav-item">
-              <Link to="#faq" className="nav-link">
+              <Link to="/#faq" className="nav-link">
                 FAQ
               </Link>
             </li>

--- a/src/pages/data-dues.md
+++ b/src/pages/data-dues.md
@@ -1,0 +1,3 @@
+---
+templateKey: data-dues-page
+---

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -16,7 +16,7 @@ hero:
         alt: support
         src: /img/handshake.png
       title: Support!
-      join_section_id: "solidarity-with-strikes"
+      join_section_id: "solidarity-with-strikers"
   title:
     - line: End student debt!
     - line: Join the strike!
@@ -117,7 +117,7 @@ join_campaign:
     image: /img/newspaper.png
     remark: Get actions when you add your name.
     title: of us are threatening to strike!
-  - id: "solidarity-with-strikes"
+  - id: "solidarity-with-strikers"
     background: /img/image_1.png
     colour: green
     content: >-

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,85 +1,89 @@
-@import url("https://fonts.googleapis.com/css?family=Libre+Franklin:400,600");
-@import url("https://s3.amazonaws.com/tds-static/fonts/moregothic/1.0.0/More+Gothic+Bold.css");
+@import url('https://fonts.googleapis.com/css?family=Libre+Franklin:400,600');
+@import url('https://s3.amazonaws.com/tds-static/fonts/moregothic/1.0.0/More+Gothic+Bold.css');
 
-$blue:                        #D8F6FF;
-$red:                         #FF4630;
-$purple:                      #DAC4F5;
-$green:                       #D6FFB8;
-$yellow:                      #FFED9C;
-$gray:                        #2b2b2b;
-$beige:                       #FAF9F5;
+$blue: #d8f6ff;
+$red: #ff4630;
+$purple: #dac4f5;
+$green: #d6ffb8;
+$yellow: #ffed9c;
+$gray: #2b2b2b;
+$beige: #faf9f5;
 
-$body-bg:                     $beige;
+$body-bg: $beige;
 
-$primary:                     $red;
+$primary: $red;
 
-$font-family-sans-serif:      "Libre Franklin",sans-serif;
-$font-family-monospace:       "More Gothic Bold", Impact, sans-serif;
-$font-weight-bold:            600;
-$font-size-base:              1.5rem;
+$font-family-sans-serif: 'Libre Franklin', sans-serif;
+$font-family-monospace: 'More Gothic Bold', Impact, sans-serif;
+$font-weight-bold: 600;
+$font-size-base: 1.5rem;
 
-$headings-margin-bottom:      0;
-$paragraph-margin-bottom:     0;
+$headings-margin-bottom: 0;
+$paragraph-margin-bottom: 0;
 
 // Avoid the need of removing margins
-$headings-margin-bottom:      0;
+$headings-margin-bottom: 0;
 
 // Grid needs to be set in px
-$grid-gutter-width:           40px;
+$grid-gutter-width: 40px;
 
 // this will allow us to create better responsive font sizes
-$display1-size:               6em;
-$display2-size:               8vw;
-$display3-size:               12.5vw;
-$display4-size:               5.5vw;
+$display1-size: 6em;
+$display2-size: 8vw;
+$display3-size: 12.5vw;
+$display4-size: 5.5vw;
 
-$display1-weight:             $font-weight-bold;
-$display2-weight:             $font-weight-bold;
-$display3-weight:             $font-weight-bold;
-$display4-weight:             $font-weight-bold;
+$display1-weight: $font-weight-bold;
+$display2-weight: $font-weight-bold;
+$display3-weight: $font-weight-bold;
+$display4-weight: $font-weight-bold;
 
 // Buttons
-$btn-padding-y:               1.3125rem;
-$btn-padding-x:               2.8rem;
+$btn-padding-y: 1.3125rem;
+$btn-padding-x: 2.8rem;
 
 // Footer
-$footer-bg:                   $gray;
-$footer-title:                #828282;
+$footer-bg: $gray;
+$footer-title: #828282;
 
 // Header
 $header-height-sm: 4rem;
 $header-height-md: 8rem;
 
 // bootstrap required
-@import "node_modules/bootstrap/scss/functions";
-@import "node_modules/bootstrap/scss/variables";
-@import "node_modules/bootstrap/scss/mixins";
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/mixins';
 
 // bootstrap optional
-@import "node_modules/bootstrap/scss/buttons";
-@import "node_modules/bootstrap/scss/close";
-@import "node_modules/bootstrap/scss/grid";
-@import "node_modules/bootstrap/scss/nav";
-@import "node_modules/bootstrap/scss/navbar";
-@import "node_modules/bootstrap/scss/reboot";
-@import "node_modules/bootstrap/scss/type";
-@import "node_modules/bootstrap/scss/utilities";
-@import "node_modules/bootstrap/scss/dropdown";
+@import 'node_modules/bootstrap/scss/reboot';
+@import 'node_modules/bootstrap/scss/type';
+@import 'node_modules/bootstrap/scss/utilities';
+@import 'node_modules/bootstrap/scss/buttons';
+@import 'node_modules/bootstrap/scss/close';
+@import 'node_modules/bootstrap/scss/grid';
+@import 'node_modules/bootstrap/scss/nav';
+@import 'node_modules/bootstrap/scss/navbar';
+@import 'node_modules/bootstrap/scss/reboot';
+@import 'node_modules/bootstrap/scss/type';
+@import 'node_modules/bootstrap/scss/utilities';
+@import 'node_modules/bootstrap/scss/dropdown';
+@import 'node_modules/bootstrap/scss/forms';
 
 // run custom code after bootstrap loaded
-@import "./functions";
-@import "./layout";
-@import "./type";
-@import "./buttons";
+@import './functions';
+@import './layout';
+@import './type';
+@import './buttons';
 
 // TODO: ideally, we shouldn't need to import those styles from here
 // styles from components and sections to allow usage of variables
-@import "../sections/Hero/style";
-@import "../sections/Informative/style";
-@import "../sections/Join/style";
-@import "../sections/Notification/style";
-@import "../sections/FAQ/style";
-@import "../sections/CTA/style";
-@import "../components/Footer/style";
-@import "../components/Header/style";
-@import "../sections/CampaignActions/style";
+@import '../sections/Hero/style';
+@import '../sections/Informative/style';
+@import '../sections/Join/style';
+@import '../sections/Notification/style';
+@import '../sections/FAQ/style';
+@import '../sections/CTA/style';
+@import '../components/Footer/style';
+@import '../components/Header/style';
+@import '../sections/CampaignActions/style';

--- a/src/templates/data-dues-page.js
+++ b/src/templates/data-dues-page.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+import Layout from "../components/Layout";
+import Header from "../components/Header";
+import DataDuesAction from "../components/DataDuesAction";
+
+export const DataDuesPageTemplate = () => {
+  return (
+    <main className="mt-5">
+      <Header />
+      <DataDuesAction />
+    </main>
+  );
+};
+
+const DataDuesPage = () => {
+  return (
+    <Layout>
+      <DataDuesPageTemplate />
+    </Layout>
+  );
+};
+
+export default DataDuesPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6473,6 +6473,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+fn-name@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
+  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
 focus-group@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/focus-group/-/focus-group-0.3.1.tgz#e0f32ed86b0dabdd6ffcebdf898ecb32e47fedce"
@@ -13109,6 +13114,11 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
+  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
 property-information@^3.0.0, property-information@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
@@ -15891,6 +15901,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synchronous-promise@^2.0.6:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.10.tgz#e64c6fd3afd25f423963353043f4a68ebd397fd8"
+  integrity sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -16217,6 +16232,11 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
   integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 touch@^2.0.1:
   version "2.0.2"
@@ -17632,6 +17652,18 @@ yoga-layout-prebuilt@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.3.tgz#11e3be29096afe3c284e5d963cc2d628148c1372"
   integrity sha512-9SNQpwuEh2NucU83i2KMZnONVudZ86YNcFk9tq74YaqrQfgJWO3yB9uzH1tAg8iqh5c9F5j0wuyJ2z72wcum2w==
+
+yup@0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.27.0.tgz#f8cb198c8e7dd2124beddc2457571329096b06e7"
+  integrity sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.11"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.6"
+    toposort "^2.0.2"
 
 yurnalist@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13482,6 +13482,11 @@ react-helmet@^5.2.0:
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
+react-hook-form@3.28.2:
+  version "3.28.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-3.28.2.tgz#eade3f0d5b1fcb9a95ac34b34fb10561712ff1da"
+  integrity sha512-aNTEIC6z7yuPqgtedAX3wwnzlIJmiSkgYnVxI+s1J8Ya4ibZl9aNRHJ6U/cSptj0KSl4Re2JqihGD9OdlEeUZQ==
+
 react-hot-loader@^4.12.16, react-hot-loader@^4.8.0:
   version "4.12.18"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.18.tgz#a9029e34af2690d76208f9a35189d73c2dfea6a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13551,6 +13551,13 @@ react-modal@^3.8.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
+react-number-format@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.3.1.tgz#eccfc851d88d74c894ba463620ccb467defbdefb"
+  integrity sha512-ze6Lp7SGM71Jr0uZhUaN6grthv08NKTfJezS26zAWZq63ubmJ++FOX7ueGSK27EvpT7/e3ce9L3jlqr1YMFS7Q==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-onclickoutside@^6.5.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,6 +774,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime-corejs2@^7.4.5":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz#5a8c4e2f8688ce58adc9eb1d8320b6e7341f96ce"
+  integrity sha512-GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
@@ -2153,7 +2161,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.7.0:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -10810,6 +10818,11 @@ nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.7.tgz#d775e3e7c6470bbaaae3da9a647a80e228e0abf7"
+  integrity sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -13505,6 +13518,24 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+react-is@^16.9.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-jsonschema-form@2.0.0-alpha.1:
+  version "2.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-2.0.0-alpha.1.tgz#385802d483dbc425091e70ad30ab6550900f9e67"
+  integrity sha512-AYpV2/dKMSNwddzrBCJjuGdbZ5jd6mD17f3tq3dzWXiK1lwb0H485u80VlKuiyvTosaMjwWtyvXhO7jXtUu7oA==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.5"
+    ajv "^6.7.0"
+    core-js "^2.5.7"
+    lodash "^4.17.15"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+    shortid "^2.2.14"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -14925,6 +14956,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.14:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
 
 sift@^5.1.0:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13513,12 +13513,7 @@ react-is@16.8.5:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
   integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
 
-react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
-  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
-
-react-is@^16.9.0:
+react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==


### PR DESCRIPTION
**What:** Implementation of the Data Dues front-end.

**Why:** Related to #32 

**How:**

- Add front-end form using `react-bootstrap`
- Add data management of the form using [react-hook-form](https://react-hook-form.com/)
- Add validations using [yup](https://github.com/jquense/yup).

This only has the front-end part. Here's a list of what is missing to have this feature completed (these will be addressed in other PRs)

- Finalize styles. Given the overrides we are making to bootstrap, styles in the form don't look good enough. I'll revisit these when we have completed the user flow.
- Backend implementation in the campaign-api repo
- Integrate the form with backend using Apollo

**Media:**

https://www.loom.com/share/2507b09964434629b38dc29b7d8409e4