### PR TITLE
Data dues integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
-    "react-hook-form": "3.28.2",
+    "react-hook-form": "3.28.7",
     "react-jsonschema-form": "2.0.0-alpha.1",
     "react-number-format": "4.3.1",
     "react-scroll": "1.7.14",

--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -22,7 +22,10 @@ export const CREATE_DATA_DUES_ACTION = gql`
   mutation createDataDuesAction($data: JSONObject!) {
     createDataDuesAction(data: $data) {
       errors
-      userAction
+      userAction {
+        id
+        completed
+      }
     }
   }
 `

--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -17,3 +17,12 @@ export const GET_USER = gql`
     }
   }
 `
+
+export const CREATE_DATA_DUES_ACTION = gql`
+  mutation createDataDuesAction($data: JSONObject!) {
+    createDataDuesAction(data: $data) {
+      errors
+      userAction
+    }
+  }
+`

--- a/src/components/DataDuesAction/fields.js
+++ b/src/components/DataDuesAction/fields.js
@@ -51,15 +51,15 @@ export const CurrencyField = ({
 
   return (
     <NumberFormat
-      type="number"
-      placeholder="$38,000"
-      isNumericString={true}
-      onValueChange={({ value }) => setValue(name, value, true)}
-      customInput={Form.Control}
-      thousandSeparator={true}
       allowNegative={false}
+      customInput={Form.Control}
       decimalScale={2}
+      isNumericString={true}
+      onValueChange={({ floatValue }) => setValue(name, floatValue, true)}
+      placeholder="$38,000"
       prefix={'$'}
+      thousandSeparator={true}
+      type="number"
       {...props}
     />
   )
@@ -86,16 +86,17 @@ export const PercentageField = ({
 
   return (
     <NumberFormat
-      placeholder="4.53%"
+      allowNegative={false}
       customInput={Form.Control}
-      onValueChange={({ value }) => setValue(name, value, true)}
-      thousandSeparator={false}
       decimalScale={2}
+      isNumericString={true}
+      onValueChange={({ floatValue }) => setValue(name, floatValue, true)}
+      placeholder="4.53%"
       suffix="%"
-      isAllowed={values => {
-        const { formattedValue, floatValue } = values
-        return formattedValue === '' || floatValue <= 100
-      }}
+      thousandSeparator={false}
+      isAllowed={({ formattedValue, floatValue }) =>
+        formattedValue === '' || floatValue <= 100
+      }
       {...props}
     />
   )

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -336,7 +336,7 @@ const DataDuesForm = () => {
   )
 
   const onSubmit = data => {
-    createDataDuesAction(data)
+    createDataDuesAction({ variables: { data } })
   }
 
   const [debtCount, setDebtCount] = useState(1)
@@ -349,10 +349,11 @@ const DataDuesForm = () => {
     setDebtCount(debtCount - 1)
   }
 
-  const { userAction } = data
-
-  if (userAction && userAction.completed) {
-    return DataDuesThankYou
+  // early return
+  // render a thank you message instead of the form
+  const { createDataDuesAction: payload } = data
+  if (payload && payload.userAction && payload.userAction.completed) {
+    return <DataDuesThankYou />
   }
 
   return (

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -308,18 +308,13 @@ const DataDuesForm = () => {
     watch,
     setValue,
     unregister,
-    errors,
-    getValues
+    errors
   } = useForm({
     validationSchema: validationSchema
   })
 
-  console.log(getValues())
-  console.log(errors)
-
   const onSubmit = data => {
-    console.log('Data', data)
-    console.log('Errors', errors)
+    console.log(data)
   }
   const [debtCount, setDebtCount] = useState(1)
 
@@ -391,18 +386,17 @@ const DataDuesForm = () => {
       <div className="mt-4">
         <h3>Your debts</h3>
         {_.range(debtCount).map(debtIndex => (
-          <>
+          <div key={debtIndex}>
             {debtIndex > 0 && <hr />}
             <DebtForm
               debtId={debtIndex}
-              key={debtIndex}
               register={register}
               watch={watch}
               unregister={unregister}
               setValue={setValue}
               errors={errors}
             />
-          </>
+          </div>
         ))}
         <div>
           <Row>

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -248,7 +248,7 @@ const DebtForm = ({
           type="radio"
           id={`beingHarrasedNo${debtId}`}
           name={`debts[${debtId}].beingHarrased`}
-          value={true}
+          value="true"
           ref={register}
           label="Yes"
           isInvalid={!!errors[`debts[${debtId}].beingHarrased`]}
@@ -262,7 +262,7 @@ const DebtForm = ({
             isInvalid={!!errors[`debts[${debtId}].beingHarrased`]}
             type="radio"
             ref={register}
-            value={false}
+            value="false"
           />
           <Form.Check.Label>No</Form.Check.Label>
           <Form.Control.Feedback type="invalid">

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -25,9 +25,10 @@ const DataDuesHeader = () => (
     <Row className="mt-4 mb-5">
       <Col>
         <p>
-          Thank you for offering your data to the Debt Collective. The more info
-          we have about the debts many of us have in common, the better we can
-          fight back together.
+          Thank you for joining the Campaign! To help us with our research we
+          are asking strikers information about the debts many of us have in
+          common. The more information we have, the better we can fight back
+          together.
         </p>
         <p className="mt-2">
           All information provided will be securely stored in our servers. We

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import useForm from 'react-hook-form'
+import { useMutation } from '@apollo/react-hooks'
 import _ from 'lodash'
 import { Container, Row, Col, Button, Form } from 'react-bootstrap'
 import { CurrencyField, PhoneNumberField, PercentageField } from './fields'
+import { CREATE_DATA_DUES_ACTION } from '../../api'
 import {
   debtTypes,
   studentDebtTypes,
@@ -11,6 +13,7 @@ import {
   unknown,
   validationSchema
 } from './schema'
+import './styles.scss'
 
 const DataDuesHeader = () => (
   <>
@@ -19,7 +22,7 @@ const DataDuesHeader = () => (
         <h1 className="text-center">Data Dues</h1>
       </Col>
     </Row>
-    <Row className="mt-4">
+    <Row className="mt-4 mb-5">
       <Col>
         <p>
           Thank you for offering your data to the Debt Collective. The more info
@@ -30,6 +33,21 @@ const DataDuesHeader = () => (
           All information provided will be securely stored in our servers. We
           won&apos;t share this information with corporations.
         </p>
+      </Col>
+    </Row>
+  </>
+)
+
+const DataDuesThankYou = () => (
+  <>
+    <Row>
+      <Col>
+        <h2 className="text-center">Thank you! 🎉</h2>
+      </Col>
+    </Row>
+    <Row className="mt-4 mb-5">
+      <Col>
+        <p>We will keep your data safe and only use it for research.</p>
       </Col>
     </Row>
   </>
@@ -313,9 +331,14 @@ const DataDuesForm = () => {
     validationSchema: validationSchema
   })
 
+  const [createDataDuesAction, { data = {}, loading }] = useMutation(
+    CREATE_DATA_DUES_ACTION
+  )
+
   const onSubmit = data => {
-    console.log(data)
+    createDataDuesAction(data)
   }
+
   const [debtCount, setDebtCount] = useState(1)
 
   const addDebt = () => {
@@ -326,10 +349,16 @@ const DataDuesForm = () => {
     setDebtCount(debtCount - 1)
   }
 
+  const { userAction } = data
+
+  if (userAction && userAction.completed) {
+    return DataDuesThankYou
+  }
+
   return (
-    <Form onSubmit={handleSubmit(onSubmit)}>
+    <Form onSubmit={handleSubmit(onSubmit)} className="data-dues-form">
       <div className="mt-4">
-        <h3>Personal information</h3>
+        <h3 className="mb-2">Personal information</h3>
         <Form.Group controlId="fullName">
           <Form.Label>Full name</Form.Label>
           <Form.Control
@@ -384,7 +413,7 @@ const DataDuesForm = () => {
       </div>
 
       <div className="mt-4">
-        <h3>Your debts</h3>
+        <h3 className="mb-2">Your debts</h3>
         {_.range(debtCount).map(debtIndex => (
           <div key={debtIndex}>
             {debtIndex > 0 && <hr />}
@@ -401,24 +430,22 @@ const DataDuesForm = () => {
         <div>
           <Row>
             <Col>
-              <Button variant="secondary" onClick={addDebt}>
-                + Add another debt
+              <Button variant="secondary" className="mr-5" onClick={addDebt}>
+                Add debt
               </Button>
-            </Col>
-            {debtCount > 1 && (
-              <Col className="text-left">
+              {debtCount > 1 && (
                 <Button variant="secondary" onClick={removeDebt}>
-                  - Remove debt
+                  Remove debt
                 </Button>
-              </Col>
-            )}
+              )}
+            </Col>
           </Row>
         </div>
       </div>
       <Row className="mt-2">
         <Col>
           <div className="text-right">
-            <Button variant="primary" type="submit">
+            <Button variant="primary" type="submit" disabled={loading}>
               Save information
             </Button>
           </div>

--- a/src/components/DataDuesAction/styles.scss
+++ b/src/components/DataDuesAction/styles.scss
@@ -1,0 +1,9 @@
+.data-dues-form {
+  .form-label {
+    margin-bottom: 0;
+  }
+
+  .btn {
+    font-size: 1rem;
+  }
+}

--- a/src/components/DataDuesAction/styles.scss
+++ b/src/components/DataDuesAction/styles.scss
@@ -5,5 +5,6 @@
 
   .btn {
     font-size: 1rem;
+    padding: 1rem 1.5rem;
   }
 }

--- a/src/components/Header/style.scss
+++ b/src/components/Header/style.scss
@@ -43,8 +43,7 @@
   flex-direction: column;
   height: $header-height-sm;
   justify-content: center;
-  transition: height 0.216s ease, background-color 0.216s ease,
-    border-color 0.216s ease;
+  transition: height 0.216s ease;
   transition-delay: 0.216s;
 
   &-col {
@@ -61,11 +60,11 @@
   &.active,
   &.slider-nav-open {
     background: $beige;
-    border-color: gray("500");
+    border-color: gray('500');
     height: $header-height-sm * $active-proportion;
 
     .logo {
-      transform: unquote("scale(#{$active-proportion})");
+      transform: unquote('scale(#{$active-proportion})');
     }
   }
 
@@ -184,7 +183,7 @@ $stripe-width-md: 4.6875rem;
   &,
   &::before,
   &::after {
-    background: gray("900");
+    background: gray('900');
     height: $stripe-height-sm;
     width: 100%;
     transform: rotate(0deg);
@@ -193,7 +192,7 @@ $stripe-width-md: 4.6875rem;
 
   &::before,
   &::after {
-    content: "";
+    content: '';
     position: absolute;
   }
 
@@ -220,7 +219,7 @@ $stripe-width-md: 4.6875rem;
 
 // bootstrap doesn't provide a way to modify the colors for nav-link
 .nav-link {
-  color: gray("900");
+  color: gray('900');
   font-weight: 600;
 }
 
@@ -236,17 +235,17 @@ $stripe-width-md: 4.6875rem;
   transition-delay: 0s;
 
   &.show {
-    transform: unquote("translate3d(0, #{$header-height-sm * 0.69}, 0)");
+    transform: unquote('translate3d(0, #{$header-height-sm * 0.69}, 0)');
     transition-delay: 0.216s;
 
     @include media-breakpoint-up(md) {
-      transform: unquote("translate3d(0, #{$header-height-md * 0.69}, 0)");
+      transform: unquote('translate3d(0, #{$header-height-md * 0.69}, 0)');
       transition-delay: 0.216s;
     }
   }
 
   .nav-item {
-    border-bottom: 0.0625rem solid gray("800");
+    border-bottom: 0.0625rem solid gray('800');
   }
 
   .nav-link {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -2,9 +2,13 @@
 
 import * as React from 'react'
 import { Helmet } from 'react-helmet'
-import Footer from '../components/Footer'
-import useSiteMetadata from './SiteMetadata'
 import { withPrefix } from 'gatsby'
+import { useQuery } from '@apollo/react-hooks'
+import Footer from './Footer'
+import Header from './Header'
+import SEO from './SEO'
+import useSiteMetadata from './SiteMetadata'
+import { GET_USER } from '../api'
 import '../styles/index.scss'
 
 if (typeof window !== 'undefined') {
@@ -18,8 +22,13 @@ type Props = {
 
 const TemplateWrapper = ({ children }: Props) => {
   const { title, description } = useSiteMetadata()
+  const { data: userQueryResponse = {} } = useQuery(GET_USER)
+  const user = userQueryResponse.currentUser || {}
+
   return (
     <>
+      <SEO />
+      <Header user={user} />
       <Helmet>
         <html lang="en" />
         <title>{title}</title>
@@ -50,7 +59,9 @@ const TemplateWrapper = ({ children }: Props) => {
         />
         <meta name="theme-color" content="#fff" />
       </Helmet>
-      {children}
+      <main id="main" className="main">
+        {children}
+      </main>
       <Footer />
     </>
   )

--- a/src/components/Profile/index.js
+++ b/src/components/Profile/index.js
@@ -14,6 +14,8 @@ const Profile = ({ user, ...rest }) => {
       <Dropdown.Toggle variant="transparent" size="sm" id="dropdown-basic">
         <div id="user-profile" className="user-profile" data-testid="profile">
           <img
+            width={50}
+            height={50}
             className="rounded-circle"
             src={user.avatar_url}
             alt={user.username}

--- a/src/sections/Hero/style.scss
+++ b/src/sections/Hero/style.scss
@@ -1,10 +1,3 @@
-.hero {
-  .distribute-rows {
-    // leave extra space for the header to be placed
-    padding-top: 8rem;
-  }
-}
-
 .display-title {
   @extend .display-3;
   @extend .text-monospace;
@@ -53,7 +46,7 @@
     }
 
     // To compensate visual
-    img[alt="fist"] {
+    img[alt='fist'] {
       margin-bottom: $spacer;
     }
   }

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -34,7 +34,7 @@ type Props = {
 }
 
 const Join = ({
-  user,
+  user = {},
   background,
   children,
   colour,

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -34,7 +34,7 @@ type Props = {
 }
 
 const Join = ({
-  user = {},
+  user,
   background,
   children,
   colour,

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import { Link, navigate } from 'gatsby'
 import { useMutation } from '@apollo/react-hooks'
 import Markdown from 'markdown-to-jsx'
 import { ADD_USER_TO_CAMPAIGN } from './api'
@@ -45,7 +46,11 @@ const Join = ({
   remark,
   title
 }: Props) => {
-  const [joinToCampaign] = useMutation(ADD_USER_TO_CAMPAIGN)
+  const [joinToCampaign] = useMutation(ADD_USER_TO_CAMPAIGN, {
+    onCompleted: data => {
+      navigate('/data-dues')
+    }
+  })
 
   return (
     <section
@@ -85,9 +90,9 @@ const Join = ({
 
                     if (user.campaigns.length) {
                       return (
-                        <div className="btn btn-primary disabled">
-                          Thanks for add your name!
-                        </div>
+                        <Link className="btn btn-primary" to="/data-dues">
+                          Go To Actions
+                        </Link>
                       )
                     }
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -9,7 +9,7 @@
     flex-direction: column;
     justify-content: space-between;
   }
-  
+
   section > & {
     padding-bottom: ($spacer * 3);
     padding-top: ($spacer * 3);
@@ -19,4 +19,8 @@
     padding-bottom: ($spacer * 6);
     padding-top: ($spacer * 6);
   }
+}
+
+.main {
+  padding-top: 8rem;
 }

--- a/src/templates/data-dues-page.js
+++ b/src/templates/data-dues-page.js
@@ -1,24 +1,17 @@
-import React from "react";
-
-import Layout from "../components/Layout";
-import Header from "../components/Header";
-import DataDuesAction from "../components/DataDuesAction";
+import React from 'react'
+import Layout from '../components/Layout'
+import DataDuesAction from '../components/DataDuesAction'
 
 export const DataDuesPageTemplate = () => {
-  return (
-    <main className="mt-5">
-      <Header />
-      <DataDuesAction />
-    </main>
-  );
-};
+  return <DataDuesAction />
+}
 
 const DataDuesPage = () => {
   return (
     <Layout>
       <DataDuesPageTemplate />
     </Layout>
-  );
-};
+  )
+}
 
-export default DataDuesPage;
+export default DataDuesPage

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -1,19 +1,15 @@
 /* eslint react/prop-types: 0 */
 
 import React from 'react'
-import { useQuery } from '@apollo/react-hooks'
 import { graphql } from 'gatsby'
 
 import Layout from '../components/Layout'
-import Header from '../components/Header'
-import SEO from '../components/SEO'
 import Hero from '../sections/Hero'
 import Informative from '../sections/Informative'
 import Join from '../sections/Join'
 import Notification from '../sections/Notification'
 import FAQ from '../sections/FAQ'
 import CTA from '../sections/CTA'
-import { GET_USER } from '../api'
 
 const IndexPage = ({ data }) => {
   const { frontmatter } = data.markdownRemark
@@ -27,13 +23,8 @@ const IndexPage = ({ data }) => {
     join_campaign: joinCampaign
   } = frontmatter
 
-  const { data: userQueryResponse = {} } = useQuery(GET_USER)
-  const user = userQueryResponse.currentUser || {}
-
   return (
     <Layout>
-      <SEO />
-      <Header user={user} />
       <Hero title={hero.title} actions={hero.actions} social={social} />
       <Informative title={demand.title} remark={demand.remark}>
         {demand.content}
@@ -60,7 +51,6 @@ const IndexPage = ({ data }) => {
             colour={colour}
             remark={remark}
             feed={feed}
-            user={user}
           >
             {content}
           </Join>

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { graphql } from 'gatsby'
-
+import { useQuery } from '@apollo/react-hooks'
 import Layout from '../components/Layout'
 import Hero from '../sections/Hero'
 import Informative from '../sections/Informative'
@@ -10,6 +10,7 @@ import Join from '../sections/Join'
 import Notification from '../sections/Notification'
 import FAQ from '../sections/FAQ'
 import CTA from '../sections/CTA'
+import { GET_USER } from '../api'
 
 const IndexPage = ({ data }) => {
   const { frontmatter } = data.markdownRemark
@@ -22,6 +23,9 @@ const IndexPage = ({ data }) => {
     demand,
     join_campaign: joinCampaign
   } = frontmatter
+
+  const { data: userQueryResponse = {} } = useQuery(GET_USER)
+  const user = userQueryResponse.currentUser || {}
 
   return (
     <Layout>
@@ -51,6 +55,7 @@ const IndexPage = ({ data }) => {
             colour={colour}
             remark={remark}
             feed={feed}
+            user={user}
           >
             {content}
           </Join>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13543,10 +13543,10 @@ react-helmet@^5.2.0:
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
-react-hook-form@3.28.2:
-  version "3.28.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-3.28.2.tgz#eade3f0d5b1fcb9a95ac34b34fb10561712ff1da"
-  integrity sha512-aNTEIC6z7yuPqgtedAX3wwnzlIJmiSkgYnVxI+s1J8Ya4ibZl9aNRHJ6U/cSptj0KSl4Re2JqihGD9OdlEeUZQ==
+react-hook-form@3.28.7:
+  version "3.28.7"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-3.28.7.tgz#2f18bed686a2847b70d61c8f8a633d926f60eff9"
+  integrity sha512-y3BttiIt2cFjbpsfTGqerz3uSADmmdcY0BTL6sxLPMyXpLkFuzB/y0MNVwMHB4VED4P1Rg0QJ3GEa6dInc+nBA==
 
 react-hot-loader@^4.12.16, react-hot-loader@^4.8.0:
   version "4.12.18"


### PR DESCRIPTION
**What:** Integrate Data dues form with Campaign API

**Why:** Closes #32 

**How:**

- Use `createDataDuesAction` mutation when submitting form
- Move Header and SEO to Layout
- Modify button label after joining a campaign to be "Go to Actions"
- After a User joins a campaign, we now redirect them to the Data dues action. This should be the list of campaigns instead of that view is missing
