### PR TITLE
Fix FAQ section content rendering

### DIFF
--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -25,7 +25,9 @@ const FAQ = ({ entries }) => (
                 className="collapsable-list__item"
               >
                 <summary className="summary">{question}</summary>
-                <Markdown className="content">{answer}</Markdown>
+                <Markdown className="content" options={{ forceBlock: true }}>
+                  {answer}
+                </Markdown>
               </details>
             ))}
           </div>

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,12 +1,22 @@
+// @flow
+
 import React from 'react'
 import Markdown from 'markdown-to-jsx'
-import PropTypes from 'prop-types'
 
 if (typeof window !== 'undefined') {
   require('details-polyfill')
 }
 
-const FAQ = ({ entries }) => (
+type FAQEntry = {
+  question: string,
+  answer: string
+}
+
+type Props = {
+  entries: Array<FAQEntry>
+}
+
+const FAQ = ({ entries }: Props) => (
   <section id="faq" className="faq">
     <div className="container-fluid distribute-rows">
       <div className="row">
@@ -36,14 +46,5 @@ const FAQ = ({ entries }) => (
     </div>
   </section>
 )
-
-FAQ.propTypes = {
-  entries: PropTypes.arrayOf(
-    PropTypes.shape({
-      question: PropTypes.string,
-      answer: PropTypes.string
-    })
-  )
-}
 
 export default FAQ

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Markdown from 'markdown-to-jsx'
 import PropTypes from 'prop-types'
 
 if (typeof window !== 'undefined') {
@@ -24,7 +25,7 @@ const FAQ = ({ entries }) => (
                 className="collapsable-list__item"
               >
                 <summary className="summary">{question}</summary>
-                <p className="content">{answer}</p>
+                <Markdown className="content">{answer}</Markdown>
               </details>
             ))}
           </div>

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -47,6 +47,10 @@ details {
     font-size: 1.125rem;
     padding-left: 1.5rem;
     margin-top: $spacer * 1.5;
+
+    > p:not(:last-child) {
+      margin-bottom: 1.5rem;
+    }
   }
 
   /*


### PR DESCRIPTION
**What:**
Add support of Markdown content to allow links to be displayed as expected within the FAQ content

**Why:**
Closes #41 

**How:**
- Use the current 'markdown-to-jsx' library 4cc3022 _(then as consequence we need 96fc788)_

**Extras:**
- Added flow typed support bcea08d

## Screenshots
![image](https://user-images.githubusercontent.com/1425162/69855648-3a3cb580-128c-11ea-9238-66407d978e99.png)
