### PR TITLE
Add configuration to support "social sharing" feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Make sure to not include last '/' on URLs
+GATSBY_ADDTHIS_PUB_ID=''
 GATSBY_CAMPAIGN_API_URL=http://lvh.me:4000
 GATSBY_COMMUNITY_URL=http://lvh.me:3000
 GATSBY_HOST_URL=http://campaign.lvh.me:8000

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,11 @@
 export { wrapRootElement } from './src/apollo/wrap-root-element'
 
 export const onInitialClientRender = () => {
+  // Avoid to add the script tag for addthis.com service is variable is not set
+  if (!process.env.GATSBY_ADDTHIS_PUB_ID) {
+    return
+  }
+
   const addThisScript = document.createElement('script')
   addThisScript.src = `//s7.addthis.com/js/300/addthis_widget.js#pubid=${process.env.GATSBY_ADDTHIS_PUB_ID}`
   document.body.appendChild(addThisScript)

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,7 @@
 export { wrapRootElement } from './src/apollo/wrap-root-element'
+
+export const onInitialClientRender = () => {
+  const addThisScript = document.createElement('script')
+  addThisScript.src = `//s7.addthis.com/js/300/addthis_widget.js#pubid=${process.env.GATSBY_ADDTHIS_PUB_ID}`
+  document.body.appendChild(addThisScript)
+}

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -13,10 +13,9 @@ import {
   unknown,
   validationSchema
 } from './schema'
-import './styles.scss'
 
 const DataDuesHeader = () => (
-  <>
+  <div id="data-dues-page" className="data-dues-page">
     <Row>
       <Col>
         <h1 className="text-center">Data Dues</h1>
@@ -36,7 +35,7 @@ const DataDuesHeader = () => (
         </p>
       </Col>
     </Row>
-  </>
+  </div>
 )
 
 const DataDuesThankYou = () => (

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -15,7 +15,7 @@ import {
 } from './schema'
 
 const DataDuesHeader = () => (
-  <div id="data-dues-page" className="data-dues-page">
+  <>
     <Row>
       <Col>
         <h1 className="text-center">Data Dues</h1>
@@ -35,7 +35,7 @@ const DataDuesHeader = () => (
         </p>
       </Col>
     </Row>
-  </div>
+  </>
 )
 
 const DataDuesThankYou = () => (

--- a/src/components/DataDuesAction/styles.scss
+++ b/src/components/DataDuesAction/styles.scss
@@ -1,7 +1,3 @@
-.data-dues-page {
-  padding-top: $header-height-md;
-}
-
 .data-dues-form {
   .form-label {
     margin-bottom: 0;

--- a/src/components/DataDuesAction/styles.scss
+++ b/src/components/DataDuesAction/styles.scss
@@ -1,3 +1,7 @@
+.data-dues-page {
+  padding-top: $header-height-md;
+}
+
 .data-dues-form {
   .form-label {
     margin-bottom: 0;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,6 +9,7 @@ import Header from './Header'
 import SEO from './SEO'
 import useSiteMetadata from './SiteMetadata'
 import { GET_USER } from '../api'
+import classNames from 'classnames'
 import '../styles/index.scss'
 
 if (typeof window !== 'undefined') {
@@ -17,13 +18,15 @@ if (typeof window !== 'undefined') {
 }
 
 type Props = {
-  children: React.Node
+  children: React.Node,
+  className?: string
 }
 
-const TemplateWrapper = ({ children }: Props) => {
+const Layout = ({ children, className }: Props) => {
   const { title, description } = useSiteMetadata()
   const { data: userQueryResponse = {} } = useQuery(GET_USER)
   const user = userQueryResponse.currentUser || {}
+  const mainClassName = classNames('main', className)
 
   return (
     <>
@@ -59,7 +62,7 @@ const TemplateWrapper = ({ children }: Props) => {
         />
         <meta name="theme-color" content="#fff" />
       </Helmet>
-      <main id="main" className="main">
+      <main id="main" className={mainClassName}>
         {children}
       </main>
       <Footer />
@@ -67,4 +70,4 @@ const TemplateWrapper = ({ children }: Props) => {
   )
 }
 
-export default TemplateWrapper
+export default Layout

--- a/src/sections/Hero/index.js
+++ b/src/sections/Hero/index.js
@@ -37,42 +37,35 @@ const Hero = ({ title, actions, social }) => (
       <div className="row">
         <div className="col">
           <div className="action-circle-wrap">
-            {actions.map(({ join_section_id: joinSectionId, title, image }, index) => (
-              <Link
-                duration={500}
-                key={joinSectionId}
-                smooth={true}
-                to={joinSectionId}
-              >
-                <div className={`action-circle bg-${getBg(index)}`}>
-                  <div className="action-circle__img">
-                    <img
-                      src={
-                        image.src.childImageSharp
-                          ? image.src.childImageSharp.fluid.src
-                          : image.src
-                      }
-                      alt={image.alt}
-                    />
+            {actions.map(
+              ({ join_section_id: joinSectionId, title, image }, index) => (
+                <Link
+                  duration={500}
+                  key={joinSectionId}
+                  smooth={true}
+                  to={joinSectionId}
+                >
+                  <div className={`action-circle bg-${getBg(index)}`}>
+                    <div className="action-circle__img">
+                      <img
+                        src={
+                          image.src.childImageSharp
+                            ? image.src.childImageSharp.fluid.src
+                            : image.src
+                        }
+                        alt={image.alt}
+                      />
+                    </div>
+                    <p className="action-circle__title">{title}</p>
                   </div>
-                  <p className="action-circle__title">{title}</p>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              )
+            )}
           </div>
         </div>
       </div>
       <div className="row d-none d-xl-flex">
-        <div className="col">
-          <div className="social-icons">
-            <p className="share-this">{social.action}</p>
-            {social.accounts.map(({ logo, username, url }, index) => (
-              <a key={`social-${index}`} href={url}>
-                <IconWrap src={logo.publicURL} alt={username} />
-              </a>
-            ))}
-          </div>
-        </div>
+        <div className="col">{/* allow to push arrow to center */}</div>
         <div className="col">
           <div className="d-flex justify-content-center">
             <IconWrap role="button" src="/img/arrow-down.svg" />

--- a/src/sections/Hero/style.scss
+++ b/src/sections/Hero/style.scss
@@ -1,3 +1,10 @@
+.hero {
+  .distribute-rows {
+    // leave extra space for the header to be placed
+    padding-top: $header-height-md;
+  }
+}
+
 .display-title {
   @extend .display-3;
   @extend .text-monospace;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -87,3 +87,4 @@ $header-height-md: 8rem;
 @import '../components/Footer/style';
 @import '../components/Header/style';
 @import '../sections/CampaignActions/style';
+@import '../components/DataDuesAction/styles';

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -20,3 +20,10 @@
     padding-top: ($spacer * 6);
   }
 }
+
+.main {
+  &:not(.no-pad) {
+    // leave extra space for the header to be placed
+    padding-top: $header-height-md;
+  }
+}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -20,7 +20,3 @@
     padding-top: ($spacer * 6);
   }
 }
-
-.main {
-  padding-top: 8rem;
-}

--- a/src/templates/data-dues-page.js
+++ b/src/templates/data-dues-page.js
@@ -3,7 +3,11 @@ import Layout from '../components/Layout'
 import DataDuesAction from '../components/DataDuesAction'
 
 export const DataDuesPageTemplate = () => {
-  return <DataDuesAction />
+  return (
+    <div id="data-dues-page" className="data-dues-page">
+      <DataDuesAction />
+    </div>
+  )
 }
 
 const DataDuesPage = () => {

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -28,7 +28,7 @@ const IndexPage = ({ data }) => {
   const user = userQueryResponse.currentUser || {}
 
   return (
-    <Layout>
+    <Layout className="no-pad">
       <Hero title={hero.title} actions={hero.actions} social={social} />
       <Informative title={demand.title} remark={demand.remark}>
         {demand.content}


### PR DESCRIPTION
**What:**
Allow users to share the page

**Why:**
Closes #22 


**How:**
Add integration with "[addthis.com](https://www.addthis.com/)" service for quick social actions management. The customisation of the widget to render is being done within their admin panel. Any further customisations or need please take also a look to https://www.addthis.com/academy/the-addthis_config-variable/

**Extras:**
- There is a minor fix at 173d1ee that allow us to keep the hero section as a truly one page scroll. _(read commit for more information)_

## Screenshots
![image](https://user-images.githubusercontent.com/1425162/69872923-25294c00-12b7-11ea-82ef-ff426f2d56ae.png)

https://www.loom.com/share/59c4ad82d3a044d898e2bdab44dadcca

**IMPORTANT:** LinkedIn integration seems to not work properly, in any case, we can decide what to show and what not from the addthis admin panel