### PR TITLE
Adopt usage of latest resolver on campaign-service "getUserActions"

### DIFF
--- a/src/sections/CampaignActions/__tests__/index.spec.js
+++ b/src/sections/CampaignActions/__tests__/index.spec.js
@@ -1,13 +1,7 @@
 import React from 'react'
 import faker from 'faker'
 import { MockedProvider } from '@apollo/react-testing'
-import {
-  render,
-  waitForElement,
-  within,
-  fireEvent,
-  waitForDomChange
-} from '@testing-library/react'
+import { render, waitForElement, within } from '@testing-library/react'
 import { userId, campaignId, fakeActions, mocks } from '../stubs'
 import CampaignActions from '../'
 
@@ -62,35 +56,6 @@ describe('<CampaignActions />', () => {
           click here to go to foo.com
         </a>
       `)
-    })
-
-    it('updates the completed state of the action after click and given delay', async () => {
-      const actionItemId = 'action-item-0'
-      const wrapper = render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <CampaignActions {...baseProps} />
-        </MockedProvider>
-      )
-
-      await waitForElement(() => wrapper.getByTestId(actionItemId))
-      const firstActionItem = within(wrapper.getByTestId(actionItemId))
-
-      // We relay on the className to understand the current visible state of the item
-      const firstActionStartsNoCompleted = document
-        .getElementById(actionItemId)
-        .classList.contains('no-completed')
-
-      fireEvent.click(firstActionItem.getByTestId('action-cta'))
-
-      await waitForDomChange()
-
-      const firstActionChangeToCompleted = document
-        .getElementById(actionItemId)
-        .classList.contains('completed')
-
-      // Assert that state of the component changes to completed after given delay
-      expect(firstActionStartsNoCompleted).toBeTruthy()
-      expect(firstActionChangeToCompleted).toBeTruthy()
     })
   })
 })

--- a/src/sections/CampaignActions/api.js
+++ b/src/sections/CampaignActions/api.js
@@ -11,16 +11,15 @@ export const UPDATE_USER_ACTION = gql`
 
 export const GET_USER_ACTIONS = gql`
   query getUserActions($userId: ID!) {
-    userActions(userId: $userId) {
+    getUserActions(userId: $userId) {
       actionId
+      userActionId
+      campaignId
+      title
+      description
+      type
+      config
       completed
-      id
-      action {
-        config
-        description
-        title
-        type
-      }
     }
   }
 `

--- a/src/sections/CampaignActions/stubs.js
+++ b/src/sections/CampaignActions/stubs.js
@@ -75,20 +75,20 @@ export const mocks = [
     },
     result: {
       data: {
-        userActions: [
+        getUserActions: [
           {
-            id: '1',
             campaignId,
+            userActionId: null,
             actionId: '4',
             completed: false,
-            action: fakeActions[0]
+            ...fakeActions[0]
           },
           {
-            id: '2',
             campaignId,
+            userActionId: null,
             actionId: '3',
             completed: false,
-            action: fakeActions[1]
+            ...fakeActions[1]
           }
         ]
       }

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -48,7 +48,7 @@ const Join = ({
 }: Props) => {
   const [joinToCampaign] = useMutation(ADD_USER_TO_CAMPAIGN, {
     onCompleted: data => {
-      navigate('/data-dues')
+      navigate('/app/actions')
     }
   })
 


### PR DESCRIPTION
**What:**
refactor(actions): update to fetch actions using the `getUserActions` latest changes

check the changes made at https://github.com/debtcollective/campaign-api/pull/19 which are the ones intended to be used with this refactor

**Why:**
re https://github.com/debtcollective/campaign-api/issues/17

**How:**
- Remove deprecated code related to "inline" update to complete the action
- Update the request to meet latest campaign-service updates

## Screenshots
![image](https://user-images.githubusercontent.com/1425162/69904241-90048100-13a4-11ea-99d9-21fa8c12c57f.png)
