### PR TITLE
Motive counter within join section

### DIFF
--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -31,9 +31,9 @@ export const GET_USER_CAMPAIGN_COUNT = gql`
   }
 `
 
-export const CREATE_DATA_DUES_ACTION = gql`
-  mutation createDataDuesAction($data: JSONObject!) {
-    createDataDuesAction(data: $data) {
+export const UPSERT_DATA_DUES_ACTION = gql`
+  mutation upsertDataDuesAction($data: JSONObject!) {
+    upsertDataDuesAction(data: $data) {
       errors
       userAction {
         id

--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -18,9 +18,22 @@ export const GET_USER = gql`
   }
 `
 
-export const UPSERT_DATA_DUES_ACTION = gql`
-  mutation upsertDataDuesAction($data: JSONObject!) {
-    upsertDataDuesAction(data: $data) {
+/**
+ * Retrieve the count of users for each campaign motive
+ */
+
+export const GET_USER_CAMPAIGN_COUNT = gql`
+  query getUserCampaignsCountByMotive {
+    getUserCampaignsCountByMotive {
+      motive
+      count
+    }
+  }
+`
+
+export const CREATE_DATA_DUES_ACTION = gql`
+  mutation createDataDuesAction($data: JSONObject!) {
+    createDataDuesAction(data: $data) {
       errors
       userAction {
         id

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,0 +1,347 @@
+---
+templateKey: index-page
+hero:
+  actions:
+    - image:
+        alt: fist
+        src: /img/fist.png
+      title: Declare!
+      join_section_id: "already-on-strike"
+    - image:
+        alt: prepare
+        src: /img/newspaper.png
+      title: Prepare!
+      join_section_id: "threatening-on-strike"
+    - image:
+        alt: support
+        src: /img/handshake.png
+      title: Support!
+      join_section_id: "solidarity-with-strikers"
+  title:
+    - line: End student debt!
+    - line: Join the strike!
+social:
+  accounts:
+    - logo: /img/twitter.svg
+      url: 'http://twitter.com/debtcollective'
+      username: debtcollective
+    - logo: /img/instagram.svg
+      url: 'http://instagram.com/debtcollective'
+      username: debtcollective
+  action: Share this!
+notification:
+  date: 'Sun, Sep 22, 2019 12:00 AM'
+  description: >-
+    **NEW** Presidential candidate Sen. Bernie Sanders has proposed  a plan to
+    eliminate the $1.6 trillion in student-loan debt held in the US and make all
+    public higher education tuition-free!
+  title: We are winning
+demand:
+  content: >-
+    Tens of million of us are carrying more than $1.5 trillion in student debt.
+    Our debt is someone's profit which also makes it a form of leverage over the
+    government agencies and the private companies that are extracting from us.
+    One million people default every year.
+  remark: We must politicize this.
+  title: >-
+    We demand full cancellation of federal & private student loans. Free public
+    college for all!
+join_campaign:
+  - id: "already-on-strike"
+    background: /img/image_3.png
+    colour: purple
+    content: >-
+      We are not paying our student loans this means we are already in default
+      or that we have enrolled in programs such as forbearance, deferment or $0
+      IBR in order to halt our payments. The government and the lenders aren't
+      getting a cent from us!
+    count: 206289
+    feed:
+      - picture: /img/ami-schneider.jpg
+        status: >-
+          I believe that education is a right. I've been fighting for debt
+          relief for years after attending Art Institute. Now I'm prepared to
+          fight for debt relief for all.
+        username: Ami Schneider.
+      - picture: /img/pam-hunt.jpg
+        status: >-
+          I am on strike because I went to school for a better job but GOT
+          SCAMMED. Education should be free. Let's do this.
+        username: Pam Hunt.
+      - picture: /img/alyse_pic.jpg
+        status: I know we can win this fight if we stand together.
+        username: Alyse Zachary.
+      - picture: /img/tribble-fam.jpg
+        status: >-
+          When our son was 3-months old, our tax refund check was stolen from us
+          by the government for student loans. We were going to get a crib for
+          our son with that tax refund check. Education should be publicly
+          funded and free. The government should not be stealing people's money
+          to pay for their mistakes.
+        username: The Tribble Family.
+    image: /img/fist.png
+    remark: Get actions when you add your name.
+    title: of us are already on strike!
+  - id: "threatening-on-strike"
+    background: /img/image_2.png
+    colour: yellow
+    content: >-
+      We are prepared to stop paying our loans in the future if our demands are
+      not met. These loans are unjust and it is only a matter of time before we
+      stop cooperating.
+    count: 891664
+    feed:
+      - picture: /img/user_1.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@laticcia'
+      - picture: /img/user_2.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@sara'
+      - picture: /img/user_3.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@monica'
+      - picture: /img/user_4.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@john'
+    image: /img/newspaper.png
+    remark: Get actions when you add your name.
+    title: of us are threatening to strike!
+  - id: "solidarity-with-strikers"
+    background: /img/image_1.png
+    colour: green
+    content: >-
+      We do not have student loans, but we are standing in solidarity with all
+      those people who are on strike
+    count: 559739
+    feed:
+      - picture: /img/user_1.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@laticca'
+      - picture: /img/user_2.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@sara'
+      - picture: /img/user_3.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@monica'
+      - picture: /img/user_4.png
+        status: >-
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. In egestas,
+          ipsum ac placerat pretium, nunc quam euismod metus, eget maximus lorem
+          nulla a arcu. Sed tempus commodo efficitur. Mauris a.
+        username: '@john'
+    image: /img/handshake.png
+    remark: Get actions when you add your name.
+    title: of us stand in solidarity with strikers.
+faq:
+  - answer: >-
+      We are debtors and supporters who are fighting for FULL student debt
+      cancellation as well as free public college. In summer 2019, two bills
+      were introduced in Congress that would do just that. For more information
+      about those bills, [go
+      here](https://community.debtcollective.org/t/organizing-to-win-college-for-all/2887)
+    question: What do Debt Collective members want?
+  - answer: >-
+      Cancelling all student debt would actually benefit low income borrowers
+      the most. Check out this [DEMOS
+      report](https://www.demos.org/publication/debt-divide-racial-and-class-bias-behind-new-normal-student-borrowing).
+      The truth is there is a deep class bias in how we finance higher
+      education. Even though some middle class and wealthier people have lots of
+      student debt, lower-income borrowers, especially black and brown people,
+      have higher balances and are more likely to leave school because they
+      can't afford to pay. Cancelling all student debt would restore our
+      commitment to education as a right while disproportionately benefitting
+      the people who most need it.
+
+
+      One reason more and more of us are having a hard time paying down our debt
+      is because the cost of college has gone up, but our pay hasn’t. Instead,
+      the labor market has "credentialized". This means that, over the last few
+      decades, people needed to take on more debt to get more degrees just to
+      get the same jobs earning the same wages as people in previous
+      generations. [As one analysis
+      shows](https://www.brookings.edu/wp-content/uploads/2016/07/PDFLooneyTextFallBPEA.pdf),
+      a result of this credentialization is that more and more people have
+      defaulted on their loans and more defaulters are low-income people and
+      racial minorities, the same people who sought college credentials to try
+      to get a pay raise that never materialized. If college led to a higher
+      paying job, then cancelling the debts of college graduates would be
+      regressive. But since most people, especially working class people, take
+      on debt for degrees that DON’T lead to better jobs, cancelling student
+      debt is NOT regressive. Want to learn more? [We refer you to economist
+      Marshall Steinbaum on this
+      question](https://www.currentaffairs.org/2019/06/is-student-debt-cancellation-regressive-no).
+    question: >-
+      What do you say to the charge that cancelling all student loans would be a
+      big giveaway to the upper middle class, in other words that it would be
+      "regressive"?
+  - answer: >-
+      When a policy is intended to help some people and not others, it is harder
+      to pass (because the people who don’t benefit are less likely to support
+      it). In addition, targeted (or what some call “means-tested”) relief would
+      not treat education as a right. As we explained above, if education is a
+      right then everyone should have access to it. For decades, college was
+      free or low cost. Making people take out loans shifted the burden of
+      paying for college onto the backs of students and families. If the
+      policies that led us to this crisis were bad, then we should correct them
+      once and for all. It’s true that full student debt cancellation will
+      benefit some relatively well-off borrowers. That’s fine by us because most
+      of the people who benefit will be regular working-class people who are
+      struggling to get by and, again, education is a right.
+    question: Why not just target relief to those carrying the biggest burden?
+  - answer: >-
+      A student debt jubilee must go hand in hand with making public college
+      tuition free. Future generations should not be burdened with student debt.
+      It is time to end it.
+    question: >-
+      What about the cost of college going forward? If we cancel all debt now,
+      what about future borrowers who would be left out?
+  - answer: >-
+      The rise in college debt has nothing to do with borrowers being
+      “irresponsible.” This is not a matter of individual behavior but of public
+      policy. No one should have ever had to go into debt for education. It is
+      awful and historically tragic that people were forced to take out loans to
+      study and for the right to prepare for a career. Our government should
+      stop harming people for simply wanting to go to college. We must return
+      education to the status of a public good.
+    question: >-
+      Students who took out loans knew what they were getting into. Why should
+      they be let out of their responsibilities?
+  - answer: >-
+      It is unfair for anyone to have been forced into debt for a basic right
+      like education. This is not a good reason to keep inflicting injustice on
+      future generations. There was a time when the US did not provide free
+      public high school, and at the time that free high school came into
+      existence there were those who had just turned 18 and missed out. The fact
+      that anyone over 18 had already missed out would not have been a good
+      reason to refuse to provide public K-12 education to everyone else. It is
+      irrational to continue with a bad policy simply because people have
+      already suffered under it. It is time to make college free, cancel student
+      debt, and liberate people to pursue their dreams.
+    question: >-
+      What do we do about the people who have already paid back all of their
+      student loans? Won’t mass debt relief be unfair to them?
+  - answer: >-
+      We are sorry you feel that way. You too should have your debts wiped out.
+      Education is a human right and should be free.
+    question: >-
+      What do you say to people who say things like, "Well, I am fortunate to
+      pay back my student loans. But I do it and so should everyone else."
+  - answer: >-
+      This is a common talking point coming from some elected officials and
+      politicians who want to continue with our current debt-financed education
+      system. Education Secretary Betsy DeVos, for example, says she opposes
+      College for All for this reason. The truth is that cancelling student debt
+      and freeing people to study without fear of debt would actually be good
+      for us all. If more funds are needed to pay for universal access to
+      college, we have a simple solution: TAX THE RICH. If poor, working and
+      middle class people are paying for others to attend school, then our
+      elected officials are failing us. Politicians should get the money from
+      Jeff Bezos. They should go after Wall Street banks. They could go after
+      the endowment funds being hoarded by rich, private universities. There is
+      plenty of money to pay for what we want; it’s just in the wrong hands. Our
+      answer to this question is: Stop fleecing working people while denying us
+      our public goods. In fact, maybe the reason billionaire Betsy DeVos and
+      company actually oppose College for All is because they don’t want their
+      taxes to go up.
+    question: >-
+      Wouldn’t cancelling student debt require people who didn’t go to college
+      to pay the tuition bills of people who did?
+  - answer: >-
+      Academic research shows that eliminating student debt for everyone would
+      provide a significant boost to the economy. Specifically, a debt jubilee
+      would  boost the economy by approximately $100 billion a year for at least
+      10 years, yielding lower unemployment rates, increased spending, and more.
+      The study also shows that full cancellation would have only a moderate
+      effect on the federal budget deficit. [Read the full report
+      here](http://www.levyinstitute.org/publications/the-macroeconomic-effects-of-student-debt-cancellation).
+    question: 'What impact will cancelling student debt have on the economy? '
+  - answer: >-
+      The good news is that it doesn’t cost very much to get rid of all student
+      debt. [A study by
+      economists](http://www.levyinstitute.org/pubs/rpr_2_6.pdf) estimated that
+      eliminating all $1.5 trillion in student debt would grow the economy by
+      $86 billion to $108 billion every year and create over a million jobs a
+      year. In total the deficit-to-GDP ratio would likely increase by
+      significantly less than 1%. We find it curious, though, that the “how will
+      you pay for it” question is never asked when politicians want to do things
+      like send American troops into other countries or raise taxes on the rich.
+      In 2018, for example, Congress passed a huge tax cut for millionaires and
+      billionaires, one of the largest in history. Did anyone bother to explain
+      how it would be paid for? The truth is that Congress has the ability to
+      authorize spending when it regards that expenditure as important for the
+      public. It’s time that they used that power for millions of people
+      drowning in student debt.
+    question: 'OK, but how do we pay for it?'
+  - answer: >
+      No. As Astra Taylor
+      [described](https://www.theguardian.com/commentisfree/2019/apr/24/elizabeth-warren-student-debt-cancel-grassroots)
+      in the Guardian and as [Luke Herrine
+      wrote](https://www.theregreview.org/2017/01/06/herrine-future-educations-power-to-cancel-debt/)
+      in a law journal, Congress has already given administrative agencies the
+      power to cancel debts. This power is called “Compromise and Settlement”
+      authority. Just as the Securities and Exchange Commission can cut
+      low-dollar deals with banks that break the law, for example, the Secretary
+      of Education
+
+      can settle with debtors for a fraction of what they owe or suspend the
+      collection of
+
+      student debt altogether. When it was first given the power to issue and
+      collect student loans in 1958, the US Department of Education also
+      received the power to “compromise, waive, or release any right” to collect
+      on them. And when the Higher Education Act of 1965 made student
+
+      loan authorities permanent, it solidified their power to compromise. We
+      believe it is time
+
+      that the Department use its authority to stop collections on student
+      loans. Nothing in the
+
+      law prevents the Secretary from doing so. Congressional authority is not
+      needed. A President who wanted to see student debt cancelled could simply
+      direct his or her Department of Education to cancel the debt.
+    question: Does Congress Have to Approve Debt Relief?
+  - answer: >-
+      Education should be free but it should also give us more liberty. Most of
+      the time, we are told that education is key to finding employment and the
+      only path out of poverty. In reality, our country’s economic problems
+      can’t be solved by education alone—producing more college graduates won’t
+      make more meaningful well-paying jobs magically appear! Nevertheless, that
+      is the message that we hear all the time. The implication is that
+      education is nothing but career training, and that if we don’t go to
+      college, we don’t deserve to make a living wage or work in a field we
+      enjoy. We oppose this kind of thinking as much as we oppose student debt.
+      The desire to study and learn is part of what makes us human. Cancelling
+      student debt and making college free would not end inequality or solve
+      other social problems. Free education means the freedom to decide what to
+      do with our lives. We want to learn in ways that we choose. We don’t want
+      to be “human capital.” We want schools organized in our interest, not in
+      the interest of lenders or employers. We know that college can be free and
+      freeing. And we are ready to fight for it.
+    question: What is education for?
+cta:
+  action: Sign up
+  title: Help Build Power. Join Today!
+---
+

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -55,7 +55,6 @@ join_campaign:
       or that we have enrolled in programs such as forbearance, deferment or $0
       IBR in order to halt our payments. The government and the lenders aren't
       getting a cent from us!
-    count: 206289
     feed:
       - picture: /img/ami-schneider.jpg
         status: >-
@@ -89,7 +88,6 @@ join_campaign:
       We are prepared to stop paying our loans in the future if our demands are
       not met. These loans are unjust and it is only a matter of time before we
       stop cooperating.
-    count: 891664
     feed:
       - picture: /img/user_1.png
         status: >-
@@ -124,7 +122,6 @@ join_campaign:
     content: >-
       We do not have student loans, but we are standing in solidarity with all
       those people who are on strike
-    count: 559739
     feed:
       - picture: /img/user_1.png
         status: >-

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -32,9 +32,6 @@ const IndexPage = ({ data }) => {
   const user = userQuery.currentUser || {}
   const counters = userCampaignCountQuery.getUserCampaignsCountByMotive || []
 
-  console.log('counters', counters)
-  console.log('joinCampaign', joinCampaign)
-
   return (
     <Layout className="no-pad">
       <Hero title={hero.title} actions={hero.actions} social={social} />
@@ -42,22 +39,28 @@ const IndexPage = ({ data }) => {
         {demand.content}
       </Informative>
       {joinCampaign.map(
-        ({ id, background, image, title, colour, content, remark, feed }) => (
-          <Join
-            key={id}
-            id={id}
-            background={background.publicURL}
-            image={image.publicURL}
-            count={_.defaultTo(_.find(counters, { motive: id }), 0)}
-            title={title}
-            colour={colour}
-            remark={remark}
-            feed={feed}
-            user={user}
-          >
-            {content}
-          </Join>
-        )
+        ({ id, background, image, title, colour, content, remark, feed }) => {
+          const countData = _.defaultTo(_.find(counters, { motive: id }), {
+            count: 0
+          })
+
+          return (
+            <Join
+              key={id}
+              id={id}
+              background={background.publicURL}
+              image={image.publicURL}
+              count={Number(countData.count)}
+              title={title}
+              colour={colour}
+              remark={remark}
+              feed={feed}
+              user={user}
+            >
+              {content}
+            </Join>
+          )
+        }
       )}
       <Notification title={notification.title} date={notification.date}>
         {notification.description}
@@ -82,7 +85,6 @@ export const indexPageQuery = graphql`
           }
           colour
           content
-          count
           feed {
             username
             status

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import { useQuery } from '@apollo/react-hooks'
+import _ from 'lodash'
 import Layout from '../components/Layout'
 import Hero from '../sections/Hero'
 import Informative from '../sections/Informative'
@@ -10,7 +11,7 @@ import Join from '../sections/Join'
 import Notification from '../sections/Notification'
 import FAQ from '../sections/FAQ'
 import CTA from '../sections/CTA'
-import { GET_USER } from '../api'
+import { GET_USER, GET_USER_CAMPAIGN_COUNT } from '../api'
 
 const IndexPage = ({ data }) => {
   const { frontmatter } = data.markdownRemark
@@ -24,8 +25,15 @@ const IndexPage = ({ data }) => {
     join_campaign: joinCampaign
   } = frontmatter
 
-  const { data: userQueryResponse = {} } = useQuery(GET_USER)
-  const user = userQueryResponse.currentUser || {}
+  const { data: userQuery = {} } = useQuery(GET_USER)
+  const { data: userCampaignCountQuery = {} } = useQuery(
+    GET_USER_CAMPAIGN_COUNT
+  )
+  const user = userQuery.currentUser || {}
+  const counters = userCampaignCountQuery.getUserCampaignsCountByMotive || []
+
+  console.log('counters', counters)
+  console.log('joinCampaign', joinCampaign)
 
   return (
     <Layout className="no-pad">
@@ -34,23 +42,13 @@ const IndexPage = ({ data }) => {
         {demand.content}
       </Informative>
       {joinCampaign.map(
-        ({
-          id,
-          background,
-          image,
-          title,
-          colour,
-          content,
-          count,
-          remark,
-          feed
-        }) => (
+        ({ id, background, image, title, colour, content, remark, feed }) => (
           <Join
             key={id}
             id={id}
             background={background.publicURL}
             image={image.publicURL}
-            count={count}
+            count={_.defaultTo(_.find(counters, { motive: id }), 0)}
             title={title}
             colour={colour}
             remark={remark}


### PR DESCRIPTION
**What:**
Consume the resolver `getUserCampaignsCountByMotive` to get the amount of users joined into a campaign due to some specific motive

**Why:**
#19 

**How:**
Add a request into index page that injects the data into "join" actions. check PR at 
https://github.com/debtcollective/campaign-api/pull/19 and https://github.com/debtcollective/campaign-api/pull/31

## Screenshots
https://www.loom.com/share/597afa8f7a894c8d87de9fbf9ea9c211