### PR TITLE
change copy on account status and student debt type fields

### DIFF
--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -214,10 +214,10 @@ const DebtForm = ({
       </Form.Group>
 
       <Form.Group controlId={`creditor${debtId}`}>
-        <Form.Label>Creditor</Form.Label>
+        <Form.Label>{isStudentDebt ? 'Servicer' : 'Creditor'}</Form.Label>
         <Form.Control
           type="text"
-          placeholder="Sallie Mae"
+          placeholder={isStudentDebt ? 'Navient' : 'Sallie Mae'}
           disabled={creditorDisabled}
           name={`debts[${debtId}].creditor`}
           ref={register}
@@ -235,7 +235,7 @@ const DebtForm = ({
           onChange={event =>
             onChange(`debts[${debtId}].creditor`, setCreditorDisabled, event)
           }
-          label="I don't know my creditor"
+          label={`I don't know my ${isStudentDebt ? 'servicer' : 'creditor'}`}
         />
       </Form.Group>
 

--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -213,7 +213,7 @@ const DebtForm = ({
         />
       </Form.Group>
 
-      <Form.Group controlId={`interestRate${debtId}`}>
+      <Form.Group controlId={`creditor${debtId}`}>
         <Form.Label>Creditor</Form.Label>
         <Form.Control
           type="text"

--- a/src/components/DataDuesAction/schema.js
+++ b/src/components/DataDuesAction/schema.js
@@ -11,15 +11,14 @@ export const debtTypes = [
   'Other'
 ]
 export const studentDebtTypes = [
-  'Subsidized Stafford',
-  'Unsubsidized Stafford',
-  'Parent PLUS',
-  'Private Student loans'
+  'Federal loan',
+  'Parent Plus loan',
+  'Private loan'
 ]
 export const accountStatuses = [
   'In repayment',
   'Late on payments',
-  'Stopped payments',
+  'Forbearance/Deferment',
   'Sent to collections'
 ]
 

--- a/src/components/DataDuesAction/schema.js
+++ b/src/components/DataDuesAction/schema.js
@@ -50,7 +50,7 @@ export const validationSchema = yup.object().shape({
         .oneOf([...studentDebtTypes, unknown], 'Student debt type is required'),
       amount: yup.number().required('Amount is required'),
       interestRate: yup.string().required('Interest rate is required'),
-      creditor: yup.string().required('Creditor is required'),
+      creditor: yup.string().required('This field is required'),
       accountStatus: yup
         .mixed()
         .oneOf([...accountStatuses, unknown], 'Account status is required'),


### PR DESCRIPTION
**What:**
change copy on account status and student debt type fields in the data dues form

**Why:**
Closes #87

**How:**
- Change input labels

**Media**
![Screen Shot 2019-12-13 at 12 40 53 PM](https://user-images.githubusercontent.com/849872/70823582-d941d100-1da5-11ea-826f-8127b1ff4ca7.png)

![Screen Shot 2019-12-13 at 12 46 39 PM](https://user-images.githubusercontent.com/849872/70823924-a2b88600-1da6-11ea-9864-94fc7eda97eb.png)

**with student debt type selected**
![image](https://user-images.githubusercontent.com/849872/70837848-1ff5f200-1dcb-11ea-91ec-9d90f1a535f8.png)

**other debt type selected**
![image](https://user-images.githubusercontent.com/849872/70837868-3308c200-1dcb-11ea-8da8-334f79c06beb.png)

