### PR TITLE
dev: bump campaign numbers while we start

### DIFF
--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -35,6 +35,12 @@ const Join = ({
 }: Props) => {
   const backgroundUrl = _.defaultTo(background.publicURL || background, '')
   const titleImageUrl = _.defaultTo(image.publicURL || image, '')
+  // We will remove this once we reach 50 strikers
+  let bumpCount = count
+
+  if (count < 100) {
+    bumpCount = count + id.length * 9
+  }
 
   return (
     <section
@@ -54,7 +60,7 @@ const Join = ({
                   alt={title.toLowerCase()}
                 />
                 <h2 className="join__title">
-                  {formatNumber(count)} {title}
+                  {formatNumber(bumpCount)} {title}
                 </h2>
               </header>
               <div className="join__content">


### PR DESCRIPTION
**What:** bump campaign numbers while we start the campaign

**Why:**
To make it look there's activity instead of showing 0 members. Closes #86 

**How:**
- Use the length of the join campaign motive and multiply it by 9.

**Media:**

![image](https://user-images.githubusercontent.com/849872/70932125-9a5a8800-1ffe-11ea-85a5-baf2e19f707d.png)

![image](https://user-images.githubusercontent.com/849872/70932153-a47c8680-1ffe-11ea-88bc-7d500232a02b.png)

![image](https://user-images.githubusercontent.com/849872/70932163-aa726780-1ffe-11ea-91f8-e327c3e23e88.png)