### PR TITLE
chore(flow): avoid having type error on <Join /> usage due to router props

### DIFF
--- a/src/components/Join/index.js
+++ b/src/components/Join/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useEffect } from 'react'
+import * as ReachRouter from '@reach/router'
 import _ from 'lodash'
 import { navigate } from 'gatsby'
 import { useMutation } from '@apollo/react-hooks'
@@ -13,9 +14,8 @@ const VALID_MOTIVES = [
 ]
 
 type Props = {
-  isLoggedIn: boolean,
-  motive: string
-}
+  isLoggedIn: boolean
+} & ReachRouter.RouteComponentProps<{ motive: string }>
 
 const Join = ({ isLoggedIn, motive }: Props) => {
   const [joinCampaign] = useMutation(ADD_USER_TO_CAMPAIGN, {

--- a/src/components/Join/index.js
+++ b/src/components/Join/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { useEffect } from 'react'
-import * as ReachRouter from '@reach/router'
+import { RouteComponentProps } from '@reach/router'
 import _ from 'lodash'
 import { navigate } from 'gatsby'
 import { useMutation } from '@apollo/react-hooks'
@@ -15,7 +15,7 @@ const VALID_MOTIVES = [
 
 type Props = {
   isLoggedIn: boolean
-} & ReachRouter.RouteComponentProps<{ motive: string }>
+} & RouteComponentProps<{ motive: string }>
 
 const Join = ({ isLoggedIn, motive }: Props) => {
   const [joinCampaign] = useMutation(ADD_USER_TO_CAMPAIGN, {

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -27,7 +27,6 @@ const App = () => {
             user={data.currentUser}
           />
           <Join
-            // FIXME: #89
             path="/app/join/:motive"
             isLoggedIn={isLoggedIn}
             user={data.currentUser}


### PR DESCRIPTION
**What:**
Add Router props support to `<Join />` component

**Why:**
Closes #89

**How:**
Use the `RouteComponentProps` type definition