### PR TITLE
fix: process.env is not an object you can deconstruct

### DIFF
--- a/src/components/Join/index.js
+++ b/src/components/Join/index.js
@@ -39,11 +39,11 @@ const Join = ({ isLoggedIn, motive }: Props) => {
 
     // redirect to login
     if (!isLoggedIn) {
-      const { GATSBY_HOST_URL, GATSBY_COMMUNITY_URL } = process.env
+      const GATSBY_HOST_URL = process.env.GATSBY_HOST_URL
+      const GATSBY_COMMUNITY_URL = process.env.GATSBY_COMMUNITY_URL
 
       if (!GATSBY_HOST_URL || !GATSBY_COMMUNITY_URL) {
-        console.error('Unable to redirect, missing env variables')
-        return
+        throw new Error('Unable to redirect, missing env variables')
       }
 
       const redirectUrl = `return_url=${GATSBY_HOST_URL}/app/join/${motive}`


### PR DESCRIPTION
**What:** fix: process.env is not an object you can deconstruct

**Why:** Fin Join component not making the redirect even when the variables are present

**How:**

- Remove process.env deconstruct