### PR TITLE
fix: fix initial render when no data dues had been submitted

### DIFF
--- a/src/components/DataDuesAction/index.js
+++ b/src/components/DataDuesAction/index.js
@@ -358,7 +358,8 @@ const DataDuesForm = ({ userAction }) => {
    * and for conditional rendering of components
    */
   const phoneNumber = watch('phoneNumber')
-  const { value: address } = watch('address')
+  const addressValue = watch('address')
+  const address = addressValue && addressValue.value
 
   const [upsertDataDuesAction, { loading }] = useMutation(
     UPSERT_DATA_DUES_ACTION,


### PR DESCRIPTION
**What:** 

Fix initial render when no data dues had been submitted

https://sentry.io/organizations/debt-collective/issues/1477875593

**Why:**

This breaks the page when no record exists in the database.

**How:**

- Setting a guard on `watch('address')` to query for value