### PR TITLE
fix: add a fixed amount to the counter without conditional

### DIFF
--- a/src/sections/Hero/index.js
+++ b/src/sections/Hero/index.js
@@ -27,14 +27,12 @@ type Props = {
 }
 
 const Hero = ({ title, actions, counters }: Props) => {
-  // Follow same principle than https://github.com/debtcollective/student-debt-campaign/commit/796b58f97171b9ebac28f8fac1146d48634510f8
   const totalCount = counters
-    .map(countByCampaign => {
-      return Number(countByCampaign.count) < 250
-        ? Number(countByCampaign.count) + 90
-        : Number(countByCampaign.count)
-    })
+    .map(countByCampaign => Number(countByCampaign.count) || 0)
     .reduce((accumulator, currentValue) => accumulator + currentValue, 0)
+
+  // Let's remove this when the campaign has a good number
+  const totalCountBump = totalCount + 90
 
   return (
     <section className="hero">
@@ -58,8 +56,8 @@ const Hero = ({ title, actions, counters }: Props) => {
               </h1>
               <p className="headline mt-xs-3 mb-sm-5 mb-xl-0 mt-xl-0">
                 There are currently{' '}
-                <span className="text-body-color">{totalCount}</span> people in
-                the fight!
+                <span className="text-body-color">{totalCountBump}</span> people
+                in the fight!
               </p>
             </div>
           </div>

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -8,6 +8,7 @@ import _ from 'lodash'
 const formatNumber = number =>
   number.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
 
+// Let's remove this when the campaign has a good number
 const bumpTable = {
   'already-on-strike': 60,
   'threatening-on-strike': 20,


### PR DESCRIPTION
**What:** add a fixed amount to the counter without conditional

**Why:**
We want to make it to a round number like 250, with our current members, we are

**How:**
Just modify the number to be 90 instead of 40

## Screenshots

![image](https://user-images.githubusercontent.com/849872/74049192-3d91a300-4999-11ea-8d0c-ad406c1cc789.png)