### PR TITLE
feat(spinner): add a spinner when a loading status is present

### DIFF
--- a/src/cms/preview-templates/IndexPagePreview.js
+++ b/src/cms/preview-templates/IndexPagePreview.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { IndexPageTemplate } from '../../templates/index-page'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { client } from '../../apollo/client'
+import Spinner from '../../components/Spinner'
 
 type Props = {
   entry: {
@@ -37,7 +38,7 @@ const IndexPagePreview = ({ entry }: Props) => {
       </ApolloProvider>
     )
   } else {
-    return <div>Loading...</div>
+    return <Spinner />
   }
 }
 

--- a/src/components/Spinner/index.js
+++ b/src/components/Spinner/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const Spinner = () => (
+  <div className="lds-roller" aria-live="polite">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+)
+
+export default Spinner

--- a/src/components/Spinner/style.scss
+++ b/src/components/Spinner/style.scss
@@ -1,0 +1,104 @@
+.lds-roller {
+  display: block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+  margin: 10rem auto;
+}
+
+.lds-roller div {
+  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  transform-origin: 40px 40px;
+}
+
+.lds-roller div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: $primary;
+  margin: -4px 0 0 -4px;
+}
+
+.lds-roller div:nth-child(1) {
+  animation-delay: -0.036s;
+}
+
+.lds-roller div:nth-child(1):after {
+  top: 63px;
+  left: 63px;
+}
+
+.lds-roller div:nth-child(2) {
+  animation-delay: -0.072s;
+}
+
+.lds-roller div:nth-child(2):after {
+  top: 68px;
+  left: 56px;
+}
+
+.lds-roller div:nth-child(3) {
+  animation-delay: -0.108s;
+}
+
+.lds-roller div:nth-child(3):after {
+  top: 71px;
+  left: 48px;
+}
+
+.lds-roller div:nth-child(4) {
+  animation-delay: -0.144s;
+}
+
+.lds-roller div:nth-child(4):after {
+  top: 72px;
+  left: 40px;
+}
+
+.lds-roller div:nth-child(5) {
+  animation-delay: -0.18s;
+}
+
+.lds-roller div:nth-child(5):after {
+  top: 71px;
+  left: 32px;
+}
+
+.lds-roller div:nth-child(6) {
+  animation-delay: -0.216s;
+}
+
+.lds-roller div:nth-child(6):after {
+  top: 68px;
+  left: 24px;
+}
+
+.lds-roller div:nth-child(7) {
+  animation-delay: -0.252s;
+}
+
+.lds-roller div:nth-child(7):after {
+  top: 63px;
+  left: 17px;
+}
+
+.lds-roller div:nth-child(8) {
+  animation-delay: -0.288s;
+}
+
+.lds-roller div:nth-child(8):after {
+  top: 56px;
+  left: 12px;
+}
+
+@keyframes lds-roller {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/sections/CampaignActions/index.js
+++ b/src/sections/CampaignActions/index.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { useQuery } from '@apollo/react-hooks'
 import CampaignAction from '../../components/CampaignAction'
+import Spinner from '../../components/Spinner'
 import CampaignActionLink from '../../components/CampaignActionLink'
 import { GET_USER_ACTIONS } from '../../api'
 
@@ -35,7 +36,7 @@ const CampaignActions = ({ user }: Props) => {
             <div data-testid="action-items" className="campaign-actions-list">
               {(() => {
                 if (queryLoading) {
-                  return <p>Loading...</p>
+                  return <Spinner />
                 }
 
                 if (queryError) {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -44,3 +44,4 @@
 @import '../sections/CampaignActions/style';
 @import '../components/DataDuesAction/styles';
 @import '../components/Alert/styles';
+@import '../components/Spinner/style';

--- a/src/templates/app/data-dues-page.js
+++ b/src/templates/app/data-dues-page.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { useQuery } from '@apollo/react-hooks'
 import DataDuesAction from '../../components/DataDuesAction'
+import Spinner from '../../components/Spinner'
 import { GET_USER_ACTION } from '../../api'
 
 type PageProps = {
@@ -18,7 +19,7 @@ const DataDuesPage = ({ user, slug, title, description }: PageProps) => {
   })
 
   if (loading) {
-    return <p>Loading...</p>
+    return <Spinner />
   }
 
   if (error) {


### PR DESCRIPTION
**What:**
Add a spinner when a loading status is present

**Why:**
Closes: https://app.asana.com/0/1159164196409129/1180381109182125/f

**How:**
- Create a Spinner component using the styles from https://loading.io/css/
- Replace the `Loading...` text for the Spinner component

## Screenshots
https://www.loom.com/share/c2f1379af335493fb788088c539ff0dc